### PR TITLE
Attempt to fix compatibility w/ Tough As Nails

### DIFF
--- a/src/main/java/com/tacz/guns/client/gameplay/LocalPlayerAim.java
+++ b/src/main/java/com/tacz/guns/client/gameplay/LocalPlayerAim.java
@@ -44,14 +44,14 @@ public class LocalPlayerAim {
         return data.clientIsAiming;
     }
 
-    public void cancelSprint(LocalPlayer player, boolean pSprinting) {
+    public boolean cancelSprint(LocalPlayer player, boolean pSprinting) {
         IGunOperator gunOperator = IGunOperator.fromLivingEntity(player);
         boolean isAiming = gunOperator.getSynIsAiming();
         ReloadState.StateType reloadStateType = gunOperator.getSynReloadState().getStateType();
         if (isAiming || (reloadStateType.isReloading() && !reloadStateType.isReloadFinishing())) {
-            player.setSprinting(false);
+            return false;
         } else {
-            player.setSprinting(pSprinting);
+            return pSprinting;
         }
     }
 

--- a/src/main/java/com/tacz/guns/mixin/client/LocalPlayerMixin.java
+++ b/src/main/java/com/tacz/guns/mixin/client/LocalPlayerMixin.java
@@ -4,17 +4,22 @@ import com.tacz.guns.api.client.gameplay.IClientPlayerGunOperator;
 import com.tacz.guns.api.entity.ShootResult;
 import com.tacz.guns.client.gameplay.*;
 import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @SuppressWarnings("ALL")
 @Mixin(LocalPlayer.class)
 public abstract class LocalPlayerMixin implements IClientPlayerGunOperator {
+    @Shadow public abstract void playNotifySound(SoundEvent pSound, SoundSource pSource, float pVolume, float pPitch);
+
     private final @Unique LocalPlayer tac$player = (LocalPlayer) (Object) this;
     private final @Unique LocalPlayerDataHolder tac$data = new LocalPlayerDataHolder(tac$player);
     private final @Unique LocalPlayerAim tac$aim = new LocalPlayerAim(tac$data, tac$player);
@@ -87,9 +92,9 @@ public abstract class LocalPlayerMixin implements IClientPlayerGunOperator {
         }
     }
 
-    @Redirect(method = "aiStep", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;setSprinting(Z)V"))
-    public void cancelSprint(LocalPlayer player, boolean sprinting) {
-        tac$aim.cancelSprint(player, sprinting);
+    @ModifyArg(method = "aiStep", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;setSprinting(Z)V"))
+    public boolean swapSprintStatus(boolean sprinting) {
+        return this.tac$aim.cancelSprint(this.tac$player, sprinting);
     }
 
     @Inject(method = "respawn", at = @At("RETURN"))


### PR DESCRIPTION
At this moment, both TaC:Z and Tough As Nails are `@Redirect`-ing `LocalPlayer::setSprint` call in `LocalPlayer#aiStep`. 

https://github.com/Glitchfiend/ToughAsNails/blob/ed18ef03b7dfd3f5a823dd2f27c581572ae2426d/common/src/main/java/toughasnails/mixin/client/MixinLocalPlayer.java#L16-L20

https://github.com/MCModderAnchor/TACZ/blob/741ebdbb3fcec6c9ee842e018e2037345807864c/src/main/java/com/tacz/guns/mixin/client/LocalPlayerMixin.java#L90-L93

Tough As Nail uses `@Redirect` on that spot to disallow sprinting when thirsty level is below a threshold. 

This PR changes the `@Redirect` in TaC:Z to `@ModifyArg`. In theory this should allow both functionalities co-existing. 

This will close #5.

![image](https://github.com/MCModderAnchor/TACZ/assets/9113033/0c432118-5e1c-4190-ab07-15fecab5275b)

