### PR TITLE
Attempt to fix compatibility w/ Epic Fight

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,9 @@ repositories {
     maven {
         // 阿里云镜像，方便国内开发
         url = uri("https://maven.aliyun.com/repository/public/")
+        content {
+            includeGroup 'org.apache.commons'
+        }
     }
     maven {
         // location of the maven that hosts JEI files since January 2023
@@ -134,6 +137,7 @@ repositories {
             includeGroup "curse.maven"
         }
     }
+    mavenCentral() // MixinExtras is there
     flatDir {
         dir 'libs'
     }
@@ -159,6 +163,13 @@ dependencies {
     compileOnly fg.deobf('libs:oculus:mc1.20.1-1.7.0')
 
     runtimeOnly fg.deobf("curse.maven:carry-on-274259:${carry_on_id}")
+
+    // 引入 MixinExtras 以解决一些棘手的 Mixin 冲突问题（比如 @Redirect 不能嵌套）
+    // 如果未来有迁移到 Fabric / NeoForge 的计划，请注意这两个框架都已自带 MixinExtras，无需自行打包。
+    compileOnly(annotationProcessor("io.github.llamalad7:mixinextras-common:0.3.6"))
+    implementation(jarJar("io.github.llamalad7:mixinextras-forge:0.3.6")) {
+        jarJar.ranged(it, "[0.3.6,)")
+    }
 
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
 }

--- a/src/main/java/com/tacz/guns/mixin/client/LocalPlayerMixin.java
+++ b/src/main/java/com/tacz/guns/mixin/client/LocalPlayerMixin.java
@@ -1,25 +1,21 @@
 package com.tacz.guns.mixin.client;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.tacz.guns.api.client.gameplay.IClientPlayerGunOperator;
 import com.tacz.guns.api.entity.ShootResult;
 import com.tacz.guns.client.gameplay.*;
 import net.minecraft.client.player.LocalPlayer;
-import net.minecraft.sounds.SoundEvent;
-import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @SuppressWarnings("ALL")
 @Mixin(LocalPlayer.class)
 public abstract class LocalPlayerMixin implements IClientPlayerGunOperator {
-    @Shadow public abstract void playNotifySound(SoundEvent pSound, SoundSource pSource, float pVolume, float pPitch);
-
     private final @Unique LocalPlayer tac$player = (LocalPlayer) (Object) this;
     private final @Unique LocalPlayerDataHolder tac$data = new LocalPlayerDataHolder(tac$player);
     private final @Unique LocalPlayerAim tac$aim = new LocalPlayerAim(tac$data, tac$player);
@@ -92,9 +88,9 @@ public abstract class LocalPlayerMixin implements IClientPlayerGunOperator {
         }
     }
 
-    @ModifyArg(method = "aiStep", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;setSprinting(Z)V"))
-    public boolean swapSprintStatus(boolean sprinting) {
-        return this.tac$aim.cancelSprint(this.tac$player, sprinting);
+    @WrapOperation(method = "aiStep", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;setSprinting(Z)V"))
+    public void swapSprintStatus(LocalPlayer player, boolean sprinting, Operation<Void> original) {
+        original.call(player, this.tac$aim.cancelSprint(player, sprinting));
     }
 
     @Inject(method = "respawn", at = @At("RETURN"))

--- a/src/main/java/com/tacz/guns/mixin/client/MouseHandlerMixin.java
+++ b/src/main/java/com/tacz/guns/mixin/client/MouseHandlerMixin.java
@@ -1,5 +1,7 @@
 package com.tacz.guns.mixin.client;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.tacz.guns.api.TimelessAPI;
 import com.tacz.guns.api.entity.IGunOperator;
 import com.tacz.guns.api.item.IAttachment;
@@ -15,34 +17,20 @@ import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 import java.util.Optional;
 
 @Mixin(MouseHandler.class)
 public class MouseHandlerMixin {
-    @ModifyArg(method = "turnPlayer", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;turn(DD)V"), index = 0)
-    public double yawSensitivity(double yaw) {
-        return tacz$reduceSensitivity(yaw);
-    }
 
-    @ModifyArg(method = "turnPlayer", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;turn(DD)V"), index = 1)
-    public double pitchSensitivity(double pitch) {
-        return tacz$reduceSensitivity(pitch);
-    }
-
-    @Unique
-    public double tacz$reduceSensitivity(double sensitivity) {
-        LocalPlayer player = Minecraft.getInstance().player;
-        if (player == null) {
-            return sensitivity;
-        }
+    @WrapOperation(method = "turnPlayer", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;turn(DD)V"))
+    public void reduceSensitivity(LocalPlayer player, double yaw, double pitch, Operation<Void> original) {
         ItemStack mainHandItem = player.getMainHandItem();
         IGun iGun = IGun.getIGunOrNull(mainHandItem);
         if (iGun == null) {
-            return sensitivity;
+            original.call(player, yaw, pitch);
+            return;
         }
         ItemStack attachment = iGun.getAttachment(mainHandItem, AttachmentType.SCOPE);
         IAttachment iAttachment = IAttachment.getIAttachmentOrNull(attachment);
@@ -72,6 +60,6 @@ public class MouseHandlerMixin {
         // 荧幕距离系数，MC 和 COD 一样使用 MDV 标准，默认为 MDV133（系数为 1.33）
         double coefficient = ZoomConfig.SCREEN_DISTANCE_COEFFICIENT.get();
         double denominator = MathUtil.zoomSensitivityRatio(currentFov, originalFov, coefficient) * sensitivityMultiplier;
-        return sensitivity * denominator;
+        original.call(player, yaw * denominator, pitch * denominator);
     }
 }

--- a/src/main/java/com/tacz/guns/mixin/common/ServerGamePacketListenerImplMixin.java
+++ b/src/main/java/com/tacz/guns/mixin/common/ServerGamePacketListenerImplMixin.java
@@ -1,24 +1,25 @@
 package com.tacz.guns.mixin.common;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.tacz.guns.api.entity.IGunOperator;
 import com.tacz.guns.api.entity.ReloadState;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(ServerGamePacketListenerImpl.class)
 public class ServerGamePacketListenerImplMixin {
-    @Redirect(method = "handlePlayerCommand", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerPlayer;setSprinting(Z)V"))
-    public void cancelSprintCommand(ServerPlayer player, boolean sprint) {
+    @WrapOperation(method = "handlePlayerCommand", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerPlayer;setSprinting(Z)V"))
+    public void cancelSprintCommand(ServerPlayer player, boolean sprint, Operation<Void> original) {
         IGunOperator gunOperator = IGunOperator.fromLivingEntity(player);
         boolean isAiming = gunOperator.getSynIsAiming();
         ReloadState.StateType reloadStateType = gunOperator.getSynReloadState().getStateType();
         if (isAiming || (reloadStateType.isReloading() && !reloadStateType.isReloadFinishing())) {
-            player.setSprinting(false);
+            original.call(player, false);
         } else {
-            player.setSprinting(sprint);
+            original.call(player, sprint);
         }
     }
 }


### PR DESCRIPTION
This will close #7, close #41, close #44.

该合并请求：

- 引入 MixinExtras
  - MixinExtras 使用 jar-in-jar 机制打包，不需要考虑 shadow 的问题
- 将 `MixinMouseHandler` 中的两个 `@ModifyArgs` 改为 MixinExtras 的 `@WrapOperation`
- 将 #6 引入的修改也用 `@WrapOperation` 重写
- 将 `ServerGamePacketListenerImplMixin` 也迁移到 `@WrapOperation` 上

使用 `@WrapOperation` 可以有效防止类似问题再次出现。

虽然 MixinExtras 在 Maven Central 上就有，但看上去阿里云的 Maven 源并没有这个。未知重新引入 Maven Central 源对其他开发者设备上的构建速度影响几何。