### PR TITLE
Depend on Figura's luaj fork for better compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,11 +157,11 @@ dependencies {
     }
 
     // LuaJ 库，将 lua 脚本语言引入用于控制枪械的逻辑和动画状态机
-    implementation(jarJar('com.github.286799714.luaj:luaj-jse:3.0.3')) {
-        jarJar.ranged(it, "[3.0.3,)")
+    implementation(jarJar('com.github.FiguraMC.luaj:luaj-jse:3.0.8-figura')) {
+        jarJar.ranged(it, "[3.0.8,)")
     }
-    implementation(jarJar('com.github.286799714.luaj:luaj-core:3.0.3')) {
-        jarJar.ranged(it, "[3.0.3,)")
+    implementation(jarJar('com.github.FiguraMC.luaj:luaj-core:3.0.8-figura')) {
+        jarJar.ranged(it, "[3.0.8,)")
     }
 
     // compile against the JEI API but do not include it at runtime

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,9 @@
+sourceControl {
+    gitRepository(URI.create("https://github.com/FiguraMC/luaj.git")) {
+    	producesModule("com.github.FiguraMC.luaj:luaj-jse-figura")
+    }
+    
+    gitRepository(URI.create("https://github.com/FiguraMC/luaj.git")) {
+    	producesModule("com.github.FiguraMC.luaj:luaj-core-figura")
+    }
+}


### PR DESCRIPTION
Title says it all. Addresses FiguraMC/Figura/issues/240  We add Figura's luaj repo as a source dependency because they have not uploaded it to a Maven repo.