### PR TITLE
Bug Fix Null Pointer Exception when gun crafting with edited default gun pack

### DIFF
--- a/src/main/java/com/tacz/guns/client/gui/GunSmithTableScreen.java
+++ b/src/main/java/com/tacz/guns/client/gui/GunSmithTableScreen.java
@@ -258,7 +258,7 @@ public class GunSmithTableScreen extends AbstractContainerScreen<GunSmithTableMe
             String type = recipeKeys.get(typeIndex);
             int xOffset = leftPos + 157 + 24 * i;
             List<ResourceLocation> recipeIdGroups = recipes.get(type);
-            if (recipeIdGroups.isEmpty()) {
+            if (recipeIdGroups == null || recipeIdGroups.isEmpty()) {
                 continue;
             }
             ItemStack icon = ItemStack.EMPTY;


### PR DESCRIPTION
**Reason for change**

After removing some items from the default gun pack (I'm creating a modpack with only the pistols, and many attachments are removed), opening the gun crafting table causes a null pointer exception as the `recipeIdGroups` is null instead of an empty object. This crashes the client.

After adding the check for `null` the user is able to use the gun crafting table without crashing.