### PR TITLE
修复弹孔在无效的方块状态上仍然渲染的错误

### DIFF
--- a/src/main/java/com/tacz/guns/client/particle/BulletHoleParticle.java
+++ b/src/main/java/com/tacz/guns/client/particle/BulletHoleParticle.java
@@ -1,6 +1,7 @@
 package com.tacz.guns.client.particle;
 
 import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.tacz.guns.GunMod;
 import com.tacz.guns.api.TimelessAPI;
 import com.tacz.guns.config.client.RenderConfig;
 import com.tacz.guns.init.ModBlocks;
@@ -21,7 +22,9 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.inventory.InventoryMenu;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.NotNull;
@@ -50,7 +53,7 @@ public class BulletHoleParticle extends TextureSheetParticle {
 
         // 如果方块是空气，则立即移除粒子
         BlockState state = world.getBlockState(pos);
-        if (world.getBlockState(pos).isAir() || state.is(ModBlocks.TARGET.get())) {
+        if (shouldRemove() || state.is(ModBlocks.TARGET.get())) {
             this.remove();
         }
         TimelessAPI.getClientGunIndex(new ResourceLocation(gunId)).ifPresent(gunIndex -> {
@@ -121,7 +124,7 @@ public class BulletHoleParticle extends TextureSheetParticle {
     @Override
     public void tick() {
         super.tick();
-        if (this.level.getBlockState(this.pos).isAir()) {
+        if (shouldRemove()) {
             this.remove();
         }
     }
@@ -179,6 +182,21 @@ public class BulletHoleParticle extends TextureSheetParticle {
     @Override
     public ParticleRenderType getRenderType() {
         return ParticleRenderType.TERRAIN_SHEET;
+    }
+
+    private boolean shouldRemove() {
+        final BlockState blockState = this.level.getBlockState(this.pos);
+        if (blockState.isAir()) {
+            return true;
+        } else {
+            // 阻止弹孔在与方块不构成有效附着时继续渲染
+            AABB baseBlockBoundingBox = blockState.getCollisionShape(this.level, this.pos).bounds();
+            AABB blockBoundingBox = baseBlockBoundingBox.move(this.pos);
+            boolean intersects = blockBoundingBox.intersects(
+                    this.x - 0.1, this.y - 0.1, this.z - 0.1,
+                    this.x + 0.1, this.y + 0.1, this.z + 0.1);
+            return !intersects;
+        }
     }
 
     @OnlyIn(Dist.CLIENT)

--- a/src/main/java/com/tacz/guns/client/particle/BulletHoleParticle.java
+++ b/src/main/java/com/tacz/guns/client/particle/BulletHoleParticle.java
@@ -189,7 +189,11 @@ public class BulletHoleParticle extends TextureSheetParticle {
             return true;
         } else {
             // 阻止弹孔在与方块不构成有效附着时继续渲染
-            AABB baseBlockBoundingBox = blockState.getCollisionShape(this.level, this.pos).bounds();
+            VoxelShape shape = blockState.getCollisionShape(this.level, this.pos);
+            if (shape.isEmpty()) {
+                return true;
+            }
+            AABB baseBlockBoundingBox = shape.bounds();
             AABB blockBoundingBox = baseBlockBoundingBox.move(this.pos);
             boolean intersects = blockBoundingBox.intersects(
                     this.x - 0.1, this.y - 0.1, this.z - 0.1,

--- a/src/main/java/com/tacz/guns/client/particle/BulletHoleParticle.java
+++ b/src/main/java/com/tacz/guns/client/particle/BulletHoleParticle.java
@@ -1,7 +1,6 @@
 package com.tacz.guns.client.particle;
 
 import com.mojang.blaze3d.vertex.VertexConsumer;
-import com.tacz.guns.GunMod;
 import com.tacz.guns.api.TimelessAPI;
 import com.tacz.guns.config.client.RenderConfig;
 import com.tacz.guns.init.ModBlocks;

--- a/src/main/java/com/tacz/guns/client/particle/BulletHoleParticle.java
+++ b/src/main/java/com/tacz/guns/client/particle/BulletHoleParticle.java
@@ -50,7 +50,6 @@ public class BulletHoleParticle extends TextureSheetParticle {
         this.gravity = 0.0F;
         this.quadSize = 0.05F;
 
-        // 如果方块是空气，则立即移除粒子
         BlockState state = world.getBlockState(pos);
         if (state.is(ModBlocks.TARGET.get()) || shouldRemove()) {
             this.remove();

--- a/src/main/java/com/tacz/guns/client/particle/BulletHoleParticle.java
+++ b/src/main/java/com/tacz/guns/client/particle/BulletHoleParticle.java
@@ -52,7 +52,7 @@ public class BulletHoleParticle extends TextureSheetParticle {
 
         // 如果方块是空气，则立即移除粒子
         BlockState state = world.getBlockState(pos);
-        if (shouldRemove() || state.is(ModBlocks.TARGET.get())) {
+        if (state.is(ModBlocks.TARGET.get()) || shouldRemove()) {
             this.remove();
         }
         TimelessAPI.getClientGunIndex(new ResourceLocation(gunId)).ifPresent(gunIndex -> {


### PR DESCRIPTION
简单重现: 拿任意枪械向门开一枪，然后打开/关闭门，在此 commit 之前弹孔会继续被渲染（因为方块没被破坏，只是状态发生了改变），呈现了一个浮空弹孔。

可能存在性能瓶颈，期待讨论。