### PR TITLE
修复当玩家的游戏模式被改为旁观时没有解除瞄准状态的问题

### DIFF
--- a/src/main/java/com/tacz/guns/api/client/gameplay/IClientPlayerGunOperator.java
+++ b/src/main/java/com/tacz/guns/api/client/gameplay/IClientPlayerGunOperator.java
@@ -57,6 +57,11 @@ public interface IClientPlayerGunOperator {
     void aim(boolean isAim);
 
     /**
+     * 重置瞄准状态
+     */
+    void aimReset();
+
+    /**
      * 客户端爬行
      */
     void crawl(boolean isCrawl);

--- a/src/main/java/com/tacz/guns/api/client/gameplay/IClientPlayerGunOperator.java
+++ b/src/main/java/com/tacz/guns/api/client/gameplay/IClientPlayerGunOperator.java
@@ -59,7 +59,7 @@ public interface IClientPlayerGunOperator {
     /**
      * 重置瞄准状态
      */
-    void aimReset();
+    void aimReset(boolean noToServerPacket);
 
     /**
      * 客户端爬行

--- a/src/main/java/com/tacz/guns/client/gameplay/LocalPlayerAim.java
+++ b/src/main/java/com/tacz/guns/client/gameplay/LocalPlayerAim.java
@@ -24,7 +24,7 @@ public class LocalPlayerAim {
 
     public void reset(boolean noToServerPacket) {
         data.clientIsAiming = false;
-        data.clientAimingProgress = 0;
+        resetData();
         if (!noToServerPacket) {
             NetworkHandler.CHANNEL.sendToServer(new ClientMessagePlayerAim(false));
         }
@@ -67,8 +67,7 @@ public class LocalPlayerAim {
         ItemStack mainhandItem = player.getMainHandItem();
         // 如果主手物品不是枪械，则取消瞄准状态并将 aimingProgress 归零，返回。
         if (!(mainhandItem.getItem() instanceof IGun iGun)) {
-            data.clientAimingProgress = 0;
-            LocalPlayerDataHolder.oldAimingProgress = 0;
+            resetData();
             return;
         }
         // 如果正在收枪，则不能瞄准
@@ -83,6 +82,11 @@ public class LocalPlayerAim {
             data.clientAimingProgress = 0;
             LocalPlayerDataHolder.oldAimingProgress = 0;
         });
+    }
+
+    private void resetData() {
+        data.clientAimingProgress = 0;
+        LocalPlayerDataHolder.oldAimingProgress = 0;
     }
 
     private void aimProgressCalculate(float alphaProgress) {

--- a/src/main/java/com/tacz/guns/client/gameplay/LocalPlayerAim.java
+++ b/src/main/java/com/tacz/guns/client/gameplay/LocalPlayerAim.java
@@ -22,6 +22,14 @@ public class LocalPlayerAim {
         this.player = player;
     }
 
+    public void reset(boolean noToServerPacket) {
+        data.clientIsAiming = false;
+        data.clientAimingProgress = 0;
+        if (!noToServerPacket) {
+            NetworkHandler.CHANNEL.sendToServer(new ClientMessagePlayerAim(false));
+        }
+    }
+
     public void aim(boolean isAim) {
         // 暂定为主手
         ItemStack mainhandItem = player.getMainHandItem();

--- a/src/main/java/com/tacz/guns/event/PlayerGameModeChangeEvent.java
+++ b/src/main/java/com/tacz/guns/event/PlayerGameModeChangeEvent.java
@@ -1,7 +1,7 @@
 package com.tacz.guns.event;
 
 import com.tacz.guns.network.NetworkHandler;
-import com.tacz.guns.network.message.ServerMessagePlayerAim;
+import com.tacz.guns.network.message.ServerMessagePlayerAimReset;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.GameType;
 import net.minecraftforge.event.entity.player.PlayerEvent;
@@ -20,7 +20,7 @@ public class PlayerGameModeChangeEvent {
         if (newGameType == GameType.SPECTATOR) {
             Player who = event.getEntity();
             if (!who.level().isClientSide) {
-                NetworkHandler.sendToClientPlayer(new ServerMessagePlayerAim(false), who);
+                NetworkHandler.sendToClientPlayer(ServerMessagePlayerAimReset.INSTANCE, who);
             }
         }
     }

--- a/src/main/java/com/tacz/guns/event/PlayerGameModeChangeEvent.java
+++ b/src/main/java/com/tacz/guns/event/PlayerGameModeChangeEvent.java
@@ -1,25 +1,30 @@
 package com.tacz.guns.event;
 
-import com.tacz.guns.network.NetworkHandler;
-import com.tacz.guns.network.message.ServerMessagePlayerAimReset;
-import net.minecraft.world.entity.player.Player;
+import com.tacz.guns.api.client.gameplay.IClientPlayerGunOperator;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.world.level.GameType;
-import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.client.event.ClientPlayerChangeGameTypeEvent;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
+@OnlyIn(Dist.CLIENT)
 @Mod.EventBusSubscriber
 public class PlayerGameModeChangeEvent {
     @SubscribeEvent(priority = EventPriority.LOWEST)
-    public static void onGameModeChange(PlayerEvent.PlayerChangeGameModeEvent event) {
+    public static void onGameModeChange(ClientPlayerChangeGameTypeEvent event) {
         if (event.isCanceled()) {
             return;
         }
-        GameType newGameType = event.getNewGameMode();
+        GameType newGameType = event.getNewGameType();
         if (newGameType == GameType.SPECTATOR) {
-            Player who = event.getEntity();
-            NetworkHandler.sendToClientPlayer(ServerMessagePlayerAimReset.INSTANCE, who);
+            LocalPlayer player = Minecraft.getInstance().player;
+            if (player != null) {
+                IClientPlayerGunOperator.fromLocalPlayer(player).aimReset(false);
+            }
         }
     }
 }

--- a/src/main/java/com/tacz/guns/event/PlayerGameModeChangeEvent.java
+++ b/src/main/java/com/tacz/guns/event/PlayerGameModeChangeEvent.java
@@ -1,0 +1,27 @@
+package com.tacz.guns.event;
+
+import com.tacz.guns.network.NetworkHandler;
+import com.tacz.guns.network.message.ServerMessagePlayerAim;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.GameType;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber
+public class PlayerGameModeChangeEvent {
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public static void onGameModeChange(PlayerEvent.PlayerChangeGameModeEvent event) {
+        if (event.isCanceled()) {
+            return;
+        }
+        GameType newGameType = event.getNewGameMode();
+        if (newGameType == GameType.SPECTATOR) {
+            Player who = event.getEntity();
+            if (!who.level().isClientSide) {
+                NetworkHandler.sendToClientPlayer(new ServerMessagePlayerAim(false), who);
+            }
+        }
+    }
+}

--- a/src/main/java/com/tacz/guns/event/PlayerGameModeChangeEvent.java
+++ b/src/main/java/com/tacz/guns/event/PlayerGameModeChangeEvent.java
@@ -19,9 +19,7 @@ public class PlayerGameModeChangeEvent {
         GameType newGameType = event.getNewGameMode();
         if (newGameType == GameType.SPECTATOR) {
             Player who = event.getEntity();
-            if (!who.level().isClientSide) {
-                NetworkHandler.sendToClientPlayer(ServerMessagePlayerAimReset.INSTANCE, who);
-            }
+            NetworkHandler.sendToClientPlayer(ServerMessagePlayerAimReset.INSTANCE, who);
         }
     }
 }

--- a/src/main/java/com/tacz/guns/mixin/client/LocalPlayerMixin.java
+++ b/src/main/java/com/tacz/guns/mixin/client/LocalPlayerMixin.java
@@ -74,6 +74,11 @@ public abstract class LocalPlayerMixin implements IClientPlayerGunOperator {
     }
 
     @Override
+    public void aimReset(boolean noToServerPacket) {
+        tac$aim.reset(noToServerPacket);
+    }
+
+    @Override
     public boolean isCrawl() {
         return tac$crawl.isCrawling();
     }

--- a/src/main/java/com/tacz/guns/network/NetworkHandler.java
+++ b/src/main/java/com/tacz/guns/network/NetworkHandler.java
@@ -92,7 +92,7 @@ public class NetworkHandler {
                 Optional.of(NetworkDirection.PLAY_TO_CLIENT));
         CHANNEL.registerMessage(ID_COUNT.getAndIncrement(), ServerMessageGunShoot.class, ServerMessageGunShoot::encode, ServerMessageGunShoot::decode, ServerMessageGunShoot::handle,
                 Optional.of(NetworkDirection.PLAY_TO_CLIENT));
-        CHANNEL.registerMessage(ID_COUNT.getAndIncrement(), ServerMessagePlayerAim.class, ServerMessagePlayerAim::encode, ServerMessagePlayerAim::decode, ServerMessagePlayerAim::handle,
+        CHANNEL.registerMessage(ID_COUNT.getAndIncrement(), ServerMessagePlayerAimReset.class, ServerMessagePlayerAimReset::encode, ServerMessagePlayerAimReset::decode, ServerMessagePlayerAimReset::handle,
                 Optional.of(NetworkDirection.PLAY_TO_CLIENT));
 
         registerAcknowledge();

--- a/src/main/java/com/tacz/guns/network/NetworkHandler.java
+++ b/src/main/java/com/tacz/guns/network/NetworkHandler.java
@@ -92,6 +92,8 @@ public class NetworkHandler {
                 Optional.of(NetworkDirection.PLAY_TO_CLIENT));
         CHANNEL.registerMessage(ID_COUNT.getAndIncrement(), ServerMessageGunShoot.class, ServerMessageGunShoot::encode, ServerMessageGunShoot::decode, ServerMessageGunShoot::handle,
                 Optional.of(NetworkDirection.PLAY_TO_CLIENT));
+        CHANNEL.registerMessage(ID_COUNT.getAndIncrement(), ServerMessagePlayerAim.class, ServerMessagePlayerAim::encode, ServerMessagePlayerAim::decode, ServerMessagePlayerAim::handle,
+                Optional.of(NetworkDirection.PLAY_TO_CLIENT));
 
         registerAcknowledge();
         registerHandshakeMessage(ServerMessageSyncedEntityDataMapping.class, null);

--- a/src/main/java/com/tacz/guns/network/message/ServerMessagePlayerAim.java
+++ b/src/main/java/com/tacz/guns/network/message/ServerMessagePlayerAim.java
@@ -1,0 +1,40 @@
+package com.tacz.guns.network.message;
+
+import com.tacz.guns.api.client.gameplay.IClientPlayerGunOperator;
+import com.tacz.guns.api.entity.IGunOperator;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.function.Supplier;
+
+public class ServerMessagePlayerAim {
+    private final boolean isAim;
+
+    public ServerMessagePlayerAim(boolean isAim) {
+        this.isAim = isAim;
+    }
+
+    public static void encode(ServerMessagePlayerAim message, FriendlyByteBuf buf) {
+        buf.writeBoolean(message.isAim);
+    }
+
+    public static ServerMessagePlayerAim decode(FriendlyByteBuf buf) {
+        return new ServerMessagePlayerAim(buf.readBoolean());
+    }
+
+    public static void handle(ServerMessagePlayerAim message, Supplier<NetworkEvent.Context> contextSupplier) {
+        NetworkEvent.Context context = contextSupplier.get();
+        if (context.getDirection().getReceptionSide().isClient()) {
+            context.enqueueWork(() -> {
+                LocalPlayer player = Minecraft.getInstance().player;
+                if (player != null) {
+                    IClientPlayerGunOperator.fromLocalPlayer(player).aim(message.isAim);
+                }
+            });
+        }
+        context.setPacketHandled(true);
+    }
+}

--- a/src/main/java/com/tacz/guns/network/message/ServerMessagePlayerAimReset.java
+++ b/src/main/java/com/tacz/guns/network/message/ServerMessagePlayerAimReset.java
@@ -32,7 +32,7 @@ public final class ServerMessagePlayerAimReset {
             context.enqueueWork(() -> {
                 LocalPlayer player = Minecraft.getInstance().player;
                 if (player != null) {
-                    IClientPlayerGunOperator.fromLocalPlayer(player).aimReset();
+                    IClientPlayerGunOperator.fromLocalPlayer(player).aimReset(true);
                 }
             });
         }

--- a/src/main/java/com/tacz/guns/network/message/ServerMessagePlayerAimReset.java
+++ b/src/main/java/com/tacz/guns/network/message/ServerMessagePlayerAimReset.java
@@ -1,37 +1,38 @@
 package com.tacz.guns.network.message;
 
 import com.tacz.guns.api.client.gameplay.IClientPlayerGunOperator;
-import com.tacz.guns.api.entity.IGunOperator;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.network.NetworkEvent;
 
 import java.util.function.Supplier;
 
-public class ServerMessagePlayerAim {
-    private final boolean isAim;
+public final class ServerMessagePlayerAimReset {
+    public static final ServerMessagePlayerAimReset INSTANCE;
 
-    public ServerMessagePlayerAim(boolean isAim) {
-        this.isAim = isAim;
+    static {
+        // noinspection InstantiationOfUtilityClass
+        INSTANCE = new ServerMessagePlayerAimReset();
     }
 
-    public static void encode(ServerMessagePlayerAim message, FriendlyByteBuf buf) {
-        buf.writeBoolean(message.isAim);
+    private ServerMessagePlayerAimReset() {
     }
 
-    public static ServerMessagePlayerAim decode(FriendlyByteBuf buf) {
-        return new ServerMessagePlayerAim(buf.readBoolean());
+    public static void encode(ServerMessagePlayerAimReset message, FriendlyByteBuf buf) {
     }
 
-    public static void handle(ServerMessagePlayerAim message, Supplier<NetworkEvent.Context> contextSupplier) {
+    public static ServerMessagePlayerAimReset decode(FriendlyByteBuf buf) {
+        return INSTANCE;
+    }
+
+    public static void handle(ServerMessagePlayerAimReset message, Supplier<NetworkEvent.Context> contextSupplier) {
         NetworkEvent.Context context = contextSupplier.get();
         if (context.getDirection().getReceptionSide().isClient()) {
             context.enqueueWork(() -> {
                 LocalPlayer player = Minecraft.getInstance().player;
                 if (player != null) {
-                    IClientPlayerGunOperator.fromLocalPlayer(player).aim(message.isAim);
+                    IClientPlayerGunOperator.fromLocalPlayer(player).aimReset();
                 }
             });
         }


### PR DESCRIPTION
为什么:
玩家在旁观模式时不能与世界交互，因而保持开镜状态是不合理的。
复现:
玩家处于开镜状态时，若服务端通知客户端其游戏模式变更为旁观，则开镜状态没有取消。