### PR TITLE
添加简单的动态准心扩散/Add simple dynamic crosshair spread

### DIFF
--- a/src/main/java/com/tacz/guns/client/event/RenderCrosshairEvent.java
+++ b/src/main/java/com/tacz/guns/client/event/RenderCrosshairEvent.java
@@ -14,6 +14,7 @@ import com.tacz.guns.api.item.IGun;
 import com.tacz.guns.client.gui.GunRefitScreen;
 import com.tacz.guns.client.renderer.crosshair.CrosshairType;
 import com.tacz.guns.compat.shouldersurfing.ShoulderSurfingCompat;
+import com.tacz.guns.compat.shouldersurfing.ShoulderSurfingCompatInner;
 import com.tacz.guns.config.client.RenderConfig;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.Options;
@@ -30,6 +31,8 @@ import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
+import java.util.Optional;
+
 
 @Mod.EventBusSubscriber(value = Dist.CLIENT, modid = GunMod.MOD_ID)
 public class RenderCrosshairEvent {
@@ -39,12 +42,20 @@ public class RenderCrosshairEvent {
     private static long hitTimestamp = -1L;
     private static long killTimestamp = -1L;
     private static long headShotTimestamp = -1L;
+    private static int shootSpread = 0;
+    private static int maxShootSpread = 20;
 
     /**
      * 当玩家手上拿着枪时，播放特定动画、或瞄准时需要隐藏准心
      */
     @SubscribeEvent(receiveCanceled = true)
     public static void onRenderOverlay(RenderGuiOverlayEvent.Pre event) {
+        if (get().filter(IClientPlayerGunOperator::isAim).isPresent()) {
+            maxShootSpread = 5;
+        } else {
+            maxShootSpread = 20;
+        }
+
         if (event.getOverlay().id().equals(VanillaGuiOverlay.CROSSHAIR.id())) {
             LocalPlayer player = Minecraft.getInstance().player;
             if (player == null) {
@@ -60,15 +71,18 @@ public class RenderCrosshairEvent {
             // 换弹进行时取消准心渲染
             ReloadState reloadState = IGunOperator.fromLivingEntity(player).getSynReloadState();
             if (reloadState.getStateType().isReloading()) {
+                shootSpreadReset();
                 return;
             }
             // 打开枪械改装界面的时候，取消准心渲染
             if (isRefitScreen) {
+                shootSpreadReset();
                 return;
             }
             // 播放的动画需要隐藏准心时，取消准心渲染
             ItemStack stack = player.getMainHandItem();
             if (!(stack.getItem() instanceof IGun)) {
+                shootSpreadReset();
                 return;
             }
 
@@ -128,7 +142,64 @@ public class RenderCrosshairEvent {
         RenderSystem.setShaderColor(1F, 1F, 1F, 0.9f);
         float x = width / 2f - 8;
         float y = height / 2f - 8;
-        graphics.blit(location, (int) x, (int) y, 0, 0, 16, 16, 16, 16);
+//        graphics.blit(location, (int) x, (int) y, 0, 0, 16, 16, 16, 16);
+
+        if (RenderConfig.CROSSHAIR_TYPE.get().name().contains("CROSS")) {
+            // center
+            graphics.blit(location, (int) (x + 7), (int) (y + 7), 7, 7, 3, 3, 16, 16);
+            // up
+            graphics.blit(location, (int) (x + 7), (int) (y - shootSpread), 7, 0, 3, 7, 16, 16);
+            // down
+            graphics.blit(location, (int) (x + 7), (int) (y + 9 + shootSpread), 7, 9, 3, 7, 16, 16);
+            // left
+            graphics.blit(location, (int) (x - shootSpread), (int) (y + 7), 0, 7, 7, 3, 16, 16);
+            // right
+            graphics.blit(location, (int) (x + 9 + shootSpread), (int) (y + 7), 9, 7, 7, 3, 16, 16);
+        } else if (RenderConfig.CROSSHAIR_TYPE.get().name().contains("SQUARE_1") || RenderConfig.CROSSHAIR_TYPE.get().name().contains("SQUARE_2") || RenderConfig.CROSSHAIR_TYPE.get().name().contains("LINE_3")) {
+            // center
+            graphics.blit(location, (int) (x + 7), (int) (y + 7), 7, 7, 3, 3, 16, 16);
+            // left
+            graphics.blit(location, (int) (x - shootSpread), (int) y, 0, 0, 7, 16, 16, 16);
+            // right
+            graphics.blit(location, (int) (x + 9 + shootSpread), (int) y, 9, 0, 7, 16, 16, 16);
+        } else if (RenderConfig.CROSSHAIR_TYPE.get().name().contains("SQUARE_3") || RenderConfig.CROSSHAIR_TYPE.get().name().contains("SQUARE_4")) {
+            // center
+            graphics.blit(location, (int) (x + 7), (int) (y + 7), 7, 7, 3, 3, 16, 16);
+            // up-left
+            graphics.blit(location, (int) (x - shootSpread / 1.414), (int) (y - (shootSpread / 1.414)), 0, 0, 7, 7, 16, 16);
+            // up-right
+            graphics.blit(location, (int) (x + 9 + shootSpread / 1.414), (int) (y - shootSpread / 1.414), 9, 0, 7, 7, 16, 16);
+            // down-left
+            graphics.blit(location, (int) (x - shootSpread / 1.414), (int) (y + 9 + shootSpread / 1.414), 0, 9, 7, 7, 16, 16);
+            // down-right
+            graphics.blit(location, (int) (x + 9 + shootSpread / 1.414), (int) (y + 9 + shootSpread / 1.414), 9, 9, 7, 7, 16, 16);
+        } else if (RenderConfig.CROSSHAIR_TYPE.get().name().contains("SQUARE_5") || RenderConfig.CROSSHAIR_TYPE.get().name().contains("SQUARE_6")) {
+            // center
+            graphics.blit(location, (int) (x + 7), (int) (y + 7), 7, 7, 3, 3, 16, 16);
+            // up
+            graphics.blit(location, (int) (x + 7), (int) (y - shootSpread), 7, 0, 3, 7, 16, 16);
+            // down
+            graphics.blit(location, (int) (x + 7), (int) (y + 9 + shootSpread), 7, 9, 3, 7, 16, 16);
+            // left
+            graphics.blit(location, (int) (x - shootSpread), (int) (y + 7), 0, 7, 7, 3, 16, 16);
+            // right
+            graphics.blit(location, (int) (x + 9 + shootSpread), (int) (y + 7), 9, 7, 7, 3, 16, 16);
+        } else if (RenderConfig.CROSSHAIR_TYPE.get().name().contains("TRIDENT")) {
+            // center
+            graphics.blit(location, (int) (x + 7), (int) (y + 7), 7, 7, 3, 3, 16, 16);
+            // up-left
+            graphics.blit(location, (int) (x - shootSpread * 0.866), (int) (y - shootSpread * 0.5), 0, 0, 7, 7, 16, 16);
+            // up-right
+            graphics.blit(location, (int) (x + 9 + shootSpread * 0.866), (int) (y - shootSpread * 0.5), 9, 0, 7, 7, 16, 16);
+            // down
+            graphics.blit(location, (int) (x + 7), (int) (y + 9 + shootSpread), 7, 9, 3, 7, 16, 16);
+        } else {
+            graphics.blit(location, (int) x, (int) y, 0, 0, 16, 16, 16, 16);
+        }
+
+        if (shootSpread > 0) {
+            shootSpread--;
+        }
     }
 
     private static void renderHitMarker(GuiGraphics graphics, Window window) {
@@ -179,5 +250,24 @@ public class RenderCrosshairEvent {
 
     public static void markHeadShotTimestamp() {
         RenderCrosshairEvent.headShotTimestamp = System.currentTimeMillis();
+    }
+
+    public static void shootSpread() {
+        if (RenderCrosshairEvent.shootSpread < maxShootSpread) {
+            if (ShoulderSurfingCompatInner.isAiming()) {
+                RenderCrosshairEvent.shootSpread += 2;
+            } else {
+                RenderCrosshairEvent.shootSpread += 10;
+            }
+        }
+    }
+
+    public static void shootSpreadReset() {
+        RenderCrosshairEvent.shootSpread = 0;
+    }
+
+    private static Optional<IClientPlayerGunOperator> get() {
+        return Optional.ofNullable(Minecraft.getInstance().player)
+                .map(IClientPlayerGunOperator::fromLocalPlayer);
     }
 }

--- a/src/main/java/com/tacz/guns/client/event/RenderCrosshairEvent.java
+++ b/src/main/java/com/tacz/guns/client/event/RenderCrosshairEvent.java
@@ -39,12 +39,20 @@ public class RenderCrosshairEvent {
     private static long hitTimestamp = -1L;
     private static long killTimestamp = -1L;
     private static long headShotTimestamp = -1L;
+    private static int shootSpread = 0;
+    private static int maxShootSpread = 20;
 
     /**
      * 当玩家手上拿着枪时，播放特定动画、或瞄准时需要隐藏准心
      */
     @SubscribeEvent(receiveCanceled = true)
     public static void onRenderOverlay(RenderGuiOverlayEvent.Pre event) {
+        if (get().filter(IClientPlayerGunOperator::isAim).isPresent()) {
+            maxShootSpread = 5;
+        } else {
+            maxShootSpread = 20;
+        }
+
         if (event.getOverlay().id().equals(VanillaGuiOverlay.CROSSHAIR.id())) {
             LocalPlayer player = Minecraft.getInstance().player;
             if (player == null) {
@@ -60,15 +68,18 @@ public class RenderCrosshairEvent {
             // 换弹进行时取消准心渲染
             ReloadState reloadState = IGunOperator.fromLivingEntity(player).getSynReloadState();
             if (reloadState.getStateType().isReloading()) {
+                shootSpreadReset();
                 return;
             }
             // 打开枪械改装界面的时候，取消准心渲染
             if (isRefitScreen) {
+                shootSpreadReset();
                 return;
             }
             // 播放的动画需要隐藏准心时，取消准心渲染
             ItemStack stack = player.getMainHandItem();
             if (!(stack.getItem() instanceof IGun)) {
+                shootSpreadReset();
                 return;
             }
 
@@ -128,7 +139,64 @@ public class RenderCrosshairEvent {
         RenderSystem.setShaderColor(1F, 1F, 1F, 0.9f);
         float x = width / 2f - 8;
         float y = height / 2f - 8;
-        graphics.blit(location, (int) x, (int) y, 0, 0, 16, 16, 16, 16);
+//        graphics.blit(location, (int) x, (int) y, 0, 0, 16, 16, 16, 16);
+
+        if (RenderConfig.CROSSHAIR_TYPE.get().name().contains("CROSS")) {
+            // center
+            graphics.blit(location, (int) (x + 7), (int) (y + 7), 7, 7, 3, 3, 16, 16);
+            // up
+            graphics.blit(location, (int) (x + 7), (int) (y - shootSpread), 7, 0, 3, 7, 16, 16);
+            // down
+            graphics.blit(location, (int) (x + 7), (int) (y + 9 + shootSpread), 7, 9, 3, 7, 16, 16);
+            // left
+            graphics.blit(location, (int) (x - shootSpread), (int) (y + 7), 0, 7, 7, 3, 16, 16);
+            // right
+            graphics.blit(location, (int) (x + 9 + shootSpread), (int) (y + 7), 9, 7, 7, 3, 16, 16);
+        } else if (RenderConfig.CROSSHAIR_TYPE.get().name().contains("SQUARE_1") || RenderConfig.CROSSHAIR_TYPE.get().name().contains("SQUARE_2") || RenderConfig.CROSSHAIR_TYPE.get().name().contains("LINE_3")) {
+            // center
+            graphics.blit(location, (int) (x + 7), (int) (y + 7), 7, 7, 3, 3, 16, 16);
+            // left
+            graphics.blit(location, (int) (x - shootSpread), (int) y, 0, 0, 7, 16, 16, 16);
+            // right
+            graphics.blit(location, (int) (x + 9 + shootSpread), (int) y, 9, 0, 7, 16, 16, 16);
+        } else if (RenderConfig.CROSSHAIR_TYPE.get().name().contains("SQUARE_3") || RenderConfig.CROSSHAIR_TYPE.get().name().contains("SQUARE_4")) {
+            // center
+            graphics.blit(location, (int) (x + 7), (int) (y + 7), 7, 7, 3, 3, 16, 16);
+            // up-left
+            graphics.blit(location, (int) (x - shootSpread / 1.414), (int) (y - (shootSpread / 1.414)), 0, 0, 7, 7, 16, 16);
+            // up-right
+            graphics.blit(location, (int) (x + 9 + shootSpread / 1.414), (int) (y - shootSpread / 1.414), 9, 0, 7, 7, 16, 16);
+            // down-left
+            graphics.blit(location, (int) (x - shootSpread / 1.414), (int) (y + 9 + shootSpread / 1.414), 0, 9, 7, 7, 16, 16);
+            // down-right
+            graphics.blit(location, (int) (x + 9 + shootSpread / 1.414), (int) (y + 9 + shootSpread / 1.414), 9, 9, 7, 7, 16, 16);
+        } else if (RenderConfig.CROSSHAIR_TYPE.get().name().contains("SQUARE_5") || RenderConfig.CROSSHAIR_TYPE.get().name().contains("SQUARE_6")) {
+            // center
+            graphics.blit(location, (int) (x + 7), (int) (y + 7), 7, 7, 3, 3, 16, 16);
+            // up
+            graphics.blit(location, (int) (x + 7), (int) (y - shootSpread), 7, 0, 3, 7, 16, 16);
+            // down
+            graphics.blit(location, (int) (x + 7), (int) (y + 9 + shootSpread), 7, 9, 3, 7, 16, 16);
+            // left
+            graphics.blit(location, (int) (x - shootSpread), (int) (y + 7), 0, 7, 7, 3, 16, 16);
+            // right
+            graphics.blit(location, (int) (x + 9 + shootSpread), (int) (y + 7), 9, 7, 7, 3, 16, 16);
+        } else if (RenderConfig.CROSSHAIR_TYPE.get().name().contains("TRIDENT")) {
+            // center
+            graphics.blit(location, (int) (x + 7), (int) (y + 7), 7, 7, 3, 3, 16, 16);
+            // up-left
+            graphics.blit(location, (int) (x - shootSpread * 0.866), (int) (y - shootSpread * 0.5), 0, 0, 7, 7, 16, 16);
+            // up-right
+            graphics.blit(location, (int) (x + 9 + shootSpread * 0.866), (int) (y - shootSpread * 0.5), 9, 0, 7, 7, 16, 16);
+            // down
+            graphics.blit(location, (int) (x + 7), (int) (y + 9 + shootSpread), 7, 9, 3, 7, 16, 16);
+        } else {
+            graphics.blit(location, (int) x, (int) y, 0, 0, 16, 16, 16, 16);
+        }
+
+        if (shootSpread > 0) {
+            shootSpread--;
+        }
     }
 
     private static void renderHitMarker(GuiGraphics graphics, Window window) {
@@ -179,5 +247,24 @@ public class RenderCrosshairEvent {
 
     public static void markHeadShotTimestamp() {
         RenderCrosshairEvent.headShotTimestamp = System.currentTimeMillis();
+    }
+
+    public static void shootSpread() {
+        if (RenderCrosshairEvent.shootSpread < maxShootSpread) {
+            if (ShoulderSurfingCompatInner.isAiming()) {
+                RenderCrosshairEvent.shootSpread += 2;
+            } else {
+                RenderCrosshairEvent.shootSpread += 10;
+            }
+        }
+    }
+
+    public static void shootSpreadReset() {
+        RenderCrosshairEvent.shootSpread = 0;
+    }
+
+    private static Optional<IClientPlayerGunOperator> get() {
+        return Optional.ofNullable(Minecraft.getInstance().player)
+                .map(IClientPlayerGunOperator::fromLocalPlayer);
     }
 }

--- a/src/main/java/com/tacz/guns/client/gameplay/LocalPlayerShoot.java
+++ b/src/main/java/com/tacz/guns/client/gameplay/LocalPlayerShoot.java
@@ -10,6 +10,7 @@ import com.tacz.guns.api.event.common.GunShootEvent;
 import com.tacz.guns.api.item.IGun;
 import com.tacz.guns.api.item.gun.FireMode;
 import com.tacz.guns.client.animation.statemachine.GunAnimationConstant;
+import com.tacz.guns.client.event.RenderCrosshairEvent;
 import com.tacz.guns.client.resource.GunDisplayInstance;
 import com.tacz.guns.client.resource.index.ClientGunIndex;
 import com.tacz.guns.client.sound.SoundPlayManager;
@@ -139,6 +140,7 @@ public class LocalPlayerShoot {
         data.isShootRecorded = false;
         // 调用开火逻辑
         this.doShoot(display, iGun, mainHandItem, gunData, coolDown);
+        RenderCrosshairEvent.shootSpread();
         return ShootResult.SUCCESS;
     }
 

--- a/src/main/java/com/tacz/guns/client/gameplay/LocalPlayerShoot.java
+++ b/src/main/java/com/tacz/guns/client/gameplay/LocalPlayerShoot.java
@@ -139,6 +139,7 @@ public class LocalPlayerShoot {
         data.isShootRecorded = false;
         // 调用开火逻辑
         this.doShoot(display, iGun, mainHandItem, gunData, coolDown);
+        RenderCrosshairEvent.shootSpread();
         return ShootResult.SUCCESS;
     }
 

--- a/src/main/java/com/tacz/guns/compat/shouldersurfing/ShoulderSurfingCompatInner.java
+++ b/src/main/java/com/tacz/guns/compat/shouldersurfing/ShoulderSurfingCompatInner.java
@@ -2,10 +2,24 @@ package com.tacz.guns.compat.shouldersurfing;
 
 import com.github.exopandora.shouldersurfing.api.model.Perspective;
 import com.github.exopandora.shouldersurfing.client.InputHandler;
+import com.tacz.guns.api.client.gameplay.IClientPlayerGunOperator;
+import net.minecraft.client.Minecraft;
+
+import java.util.Optional;
 
 public class ShoulderSurfingCompatInner {
     public static boolean showCrosshair() {
         Perspective current = Perspective.current();
-        return current == Perspective.SHOULDER_SURFING && !InputHandler.FREE_LOOK.isDown();
+        return current == Perspective.SHOULDER_SURFING && !InputHandler.FREE_LOOK.isDown() && isAiming();
+    }
+
+    // 参考: https://github.com/ChloePrime/Third-Person-Shooting-Zero/blob/master/src/main/java/mod/chloeprime/thirdpersonshooting/client/LocalGunner.java
+    private static Optional<IClientPlayerGunOperator> get() {
+        return Optional.ofNullable(Minecraft.getInstance().player)
+                .map(IClientPlayerGunOperator::fromLocalPlayer);
+    }
+
+    public static boolean isAiming() {
+        return get().filter(IClientPlayerGunOperator::isAim).isPresent();
     }
 }

--- a/src/main/java/com/tacz/guns/compat/shouldersurfing/ShoulderSurfingPlugin.java
+++ b/src/main/java/com/tacz/guns/compat/shouldersurfing/ShoulderSurfingPlugin.java
@@ -7,6 +7,13 @@ import com.tacz.guns.api.item.IGun;
 public class ShoulderSurfingPlugin implements IShoulderSurfingPlugin {
 	@Override
 	public void register(IShoulderSurfingRegistrar registrar) {
-		registrar.registerAdaptiveItemCallback(itemStack -> itemStack.getItem() instanceof IGun);
+		registrar.registerAdaptiveItemCallback(
+				itemStack -> {
+					if (!(itemStack.getItem() instanceof IGun)) {
+						return false;
+					}
+					return ShoulderSurfingCompatInner.isAiming();
+				}
+		);
 	}
 }


### PR DESCRIPTION
修改了 `renderCrosshair` 方法中的准星渲染逻辑：玩家射击时准星会扩大，随后随时间推移逐渐收缩，且扩散幅度会根据玩家是否处于瞄准状态而有所不同（适配 shoulder surfing)
TODO：根据不同枪械的数据适配不同的扩散

Modified the crosshair rendering logic in the `renderCrosshair` method: when the player shoots, the crosshair expands and then gradually contracts over time, with the spread magnitude varying depending on whether the player is in an aiming state (with support for shoulder surfing).
TODO: Adapt crosshair spread based on the data of different firearms.