### PR TITLE
更正注释描述

### DIFF
--- a/src/main/java/com/tacz/guns/api/event/common/GunDrawEvent.java
+++ b/src/main/java/com/tacz/guns/api/event/common/GunDrawEvent.java
@@ -6,7 +6,7 @@ import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.LogicalSide;
 
 /**
- * 生物开始更换枪械弹药时触发的事件。
+ * 生物开始切换枪械时触发的事件。
  */
 public class GunDrawEvent extends Event implements KubeJSGunEventPoster<GunDrawEvent>{
     private final LivingEntity entity;


### PR DESCRIPTION
GunDrawEvent的注释描述有误：
- 当前注释：换弹时触发
- 实际行为：切枪（拔枪/收枪）时触发