### PR TITLE
对1.20.1更高射速武器的适配

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -241,6 +241,9 @@ dependencies {
         jarJar.ranged(it, "[0.3.6,)")
     }
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
+    jarJar('it.unimi.dsi:fastutil:8.5.18') {
+        jarJar.ranged(it, '[8.5,9.0)')
+    }
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ apply plugin: 'eclipse'
 apply plugin: 'org.spongepowered.mixin'
 apply plugin: 'java'
 
-version = "1.1.7-hotfix"
+version = "1.1.8-hotfix"
 // 版本号，正式发布需要修改这一行
 //version = FORMAT.format(new Date())
 group = "com.tacz"

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ apply plugin: 'eclipse'
 apply plugin: 'org.spongepowered.mixin'
 apply plugin: 'java'
 
-version = "1.1.8-hotfix"
+version = "1.1.7-hotfix"
 // 版本号，正式发布需要修改这一行
 //version = FORMAT.format(new Date())
 group = "com.tacz"
@@ -241,9 +241,12 @@ dependencies {
         jarJar.ranged(it, "[0.3.6,)")
     }
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
-    jarJar('it.unimi.dsi:fastutil:8.5.18') {
+    implementation 'it.unimi.dsi:fastutil:8.5.18'
+    /*
+    implementation(jarJar('it.unimi.dsi:fastutil:8.5.18')) {
         jarJar.ranged(it, '[8.5,9.0)')
-    }
+    }*/
+    annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
 }
 
 jar {

--- a/src/main/java/com/tacz/guns/GunMod.java
+++ b/src/main/java/com/tacz/guns/GunMod.java
@@ -29,7 +29,6 @@ public class GunMod {
      * 默认模型包文件夹
      */
     public static final String DEFAULT_GUN_PACK_NAME = "tacz_default_gun";
-
     public GunMod() {
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, CommonConfig.init());
         ModLoadingContext.get().registerConfig(ModConfig.Type.SERVER, ServerConfig.init());

--- a/src/main/java/com/tacz/guns/GunMod.java
+++ b/src/main/java/com/tacz/guns/GunMod.java
@@ -56,7 +56,6 @@ public class GunMod {
 
         registerDefaultExtraGunPack();
         AttachmentPropertyManager.registerModifier();
-        ShootBus shootBus = new ShootBus();
     }
 
     private static void registerDefaultExtraGunPack() {

--- a/src/main/java/com/tacz/guns/GunMod.java
+++ b/src/main/java/com/tacz/guns/GunMod.java
@@ -8,6 +8,7 @@ import com.tacz.guns.config.ServerConfig;
 import com.tacz.guns.init.*;
 import com.tacz.guns.resource.GunPackLoader;
 import com.tacz.guns.resource.modifier.AttachmentPropertyManager;
+import com.tacz.guns.util.ShootBus;
 import net.minecraft.server.packs.PackType;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.eventbus.api.IEventBus;
@@ -56,6 +57,7 @@ public class GunMod {
 
         registerDefaultExtraGunPack();
         AttachmentPropertyManager.registerModifier();
+        ShootBus shootBus = new ShootBus();
     }
 
     private static void registerDefaultExtraGunPack() {

--- a/src/main/java/com/tacz/guns/api/client/gameplay/IClientPlayerGunOperator.java
+++ b/src/main/java/com/tacz/guns/api/client/gameplay/IClientPlayerGunOperator.java
@@ -27,6 +27,8 @@ public interface IClientPlayerGunOperator {
      */
     ShootResult shoot();
 
+    boolean stopFullAuto();
+
     /**
      * 执行客户端切枪逻辑。
      */

--- a/src/main/java/com/tacz/guns/api/client/gameplay/IClientPlayerGunOperator.java
+++ b/src/main/java/com/tacz/guns/api/client/gameplay/IClientPlayerGunOperator.java
@@ -27,7 +27,10 @@ public interface IClientPlayerGunOperator {
      */
     ShootResult shoot();
 
-    boolean stopFullAuto();
+    /**
+     * 停止全自动射击
+     */
+    void stopFullAuto();
 
     /**
      * 执行客户端切枪逻辑。

--- a/src/main/java/com/tacz/guns/api/entity/IGunOperator.java
+++ b/src/main/java/com/tacz/guns/api/entity/IGunOperator.java
@@ -125,10 +125,10 @@ public interface IGunOperator {
      * @param yaw   开火方向的偏航角(即 yRot )
      * @param timestamp 指定的时间戳，为偏移时间戳（相对于 base timestamp 的时间戳）
      * @param count 包含的弹药数
-     * @param source true为来自服务器，false为来自客户端
+     * @param fromServer true为来自服务器，false为来自客户端
      * @return 本次射击的结果
      */
-    ShootResult shoot(Supplier<Float> pitch, Supplier<Float> yaw, long timestamp, int count, boolean source);
+    ShootResult shoot(Supplier<Float> pitch, Supplier<Float> yaw, long timestamp, int count, boolean fromServer);
 
     /**
      * 开始全自动射击

--- a/src/main/java/com/tacz/guns/api/entity/IGunOperator.java
+++ b/src/main/java/com/tacz/guns/api/entity/IGunOperator.java
@@ -118,11 +118,28 @@ public interface IGunOperator {
      */
     ShootResult shoot(Supplier<Float> pitch, Supplier<Float> yaw, long timestamp);
 
+    /**
+     * 从实体的位置，向指定的方向开枪。计算冷却的时候使用指定的 timestamp。指定包含的弹药数和射击发起的来源
+     *
+     * @param pitch 开火方向的俯仰角(即 xRot )
+     * @param yaw   开火方向的偏航角(即 yRot )
+     * @param timestamp 指定的时间戳，为偏移时间戳（相对于 base timestamp 的时间戳）
+     * @param count 包含的弹药数
+     * @param source true为来自服务器，false为来自客户端
+     * @return 本次射击的结果
+     */
     ShootResult shoot(Supplier<Float> pitch, Supplier<Float> yaw, long timestamp, int count, boolean source);
 
-    boolean startFullAuto(long timestamp);
+    /**
+     * 开始全自动射击
+     * @param timestamp 开始的时间戳
+     */
+    void startFullAuto(long timestamp);
 
-    boolean stopFullAuto(long timestamp);
+    /**
+     * 停止全自动射击
+     */
+    void stopFullAuto();
 
     /**
      * 服务端，该操作者是否受弹药数影响

--- a/src/main/java/com/tacz/guns/api/entity/IGunOperator.java
+++ b/src/main/java/com/tacz/guns/api/entity/IGunOperator.java
@@ -118,6 +118,12 @@ public interface IGunOperator {
      */
     ShootResult shoot(Supplier<Float> pitch, Supplier<Float> yaw, long timestamp);
 
+    ShootResult shoot(Supplier<Float> pitch, Supplier<Float> yaw, long timestamp, int count, boolean source);
+
+    boolean startFullAuto(long timestamp);
+
+    boolean stopFullAuto(long timestamp);
+
     /**
      * 服务端，该操作者是否受弹药数影响
      *

--- a/src/main/java/com/tacz/guns/api/item/gun/AbstractGunItem.java
+++ b/src/main/java/com/tacz/guns/api/item/gun/AbstractGunItem.java
@@ -227,21 +227,25 @@ public abstract class AbstractGunItem extends Item implements IGun, IAnimationIt
     public int findAndExtractInventoryAmmos(IItemHandler itemHandler, ItemStack gunItem, int needAmmoCount) {
         return findAndExtractInventoryAmmo(itemHandler, gunItem, needAmmoCount);
     }
-
+    public int findAndExtractInventoryAmmo(IItemHandler itemHandler, ItemStack gunItem, int needAmmoCount) {
+        return findAndExtractInventoryAmmo(itemHandler, gunItem,  needAmmoCount, false);
+    }
     /**
      * 枪械寻弹和扣除背包弹药逻辑
      * @param itemHandler 目标实体的背包
      * @param gunItem 枪械物品
      * @param needAmmoCount 需要的弹药 (物品) 数量
+     * @param simulate 如果为 {@code true}，则仅测试是否可以消耗子弹，不实际修改数量；
+     *                 如果为 {@code false}，则真实消耗子弹。
      * @return 寻找到的弹药 (物品) 数量
      */
-    public int findAndExtractInventoryAmmo(IItemHandler itemHandler, ItemStack gunItem, int needAmmoCount) {
+    public int findAndExtractInventoryAmmo(IItemHandler itemHandler, ItemStack gunItem, int needAmmoCount, boolean simulate) {
         int cnt = needAmmoCount;
         // 背包检查
         for (int i = 0; i < itemHandler.getSlots(); i++) {
             ItemStack checkAmmoStack = itemHandler.getStackInSlot(i);
             if (checkAmmoStack.getItem() instanceof IAmmo iAmmo && iAmmo.isAmmoOfGun(gunItem, checkAmmoStack)) {
-                ItemStack extractItem = itemHandler.extractItem(i, cnt, false);
+                ItemStack extractItem = itemHandler.extractItem(i, cnt, simulate);
                 cnt = cnt - extractItem.getCount();
                 if (cnt <= 0) {
                     break;
@@ -251,9 +255,11 @@ public abstract class AbstractGunItem extends Item implements IGun, IAnimationIt
                 int boxAmmoCount = iAmmoBox.getAmmoCount(checkAmmoStack);
                 int extractCount = Math.min(boxAmmoCount, cnt);
                 int remainCount = boxAmmoCount - extractCount;
-                iAmmoBox.setAmmoCount(checkAmmoStack, remainCount);
-                if (remainCount <= 0) {
-                    iAmmoBox.setAmmoId(checkAmmoStack, DefaultAssets.EMPTY_AMMO_ID);
+                if (!simulate) {
+                    iAmmoBox.setAmmoCount(checkAmmoStack, remainCount);
+                    if (remainCount <= 0) {
+                        iAmmoBox.setAmmoId(checkAmmoStack, DefaultAssets.EMPTY_AMMO_ID);
+                    }
                 }
                 cnt = cnt - extractCount;
                 if (cnt <= 0) {

--- a/src/main/java/com/tacz/guns/api/item/gun/AbstractGunItem.java
+++ b/src/main/java/com/tacz/guns/api/item/gun/AbstractGunItem.java
@@ -62,7 +62,7 @@ public abstract class AbstractGunItem extends Item implements IGun, IAnimationIt
     /**
      * 射击时触发
      */
-    public abstract void shoot(ShooterDataHolder dataHolder, ItemStack gunItem, Supplier<Float> pitch, Supplier<Float> yaw, LivingEntity shooter);
+    public abstract void shoot(ShooterDataHolder dataHolder, ItemStack gunItem, Supplier<Float> pitch, Supplier<Float> yaw, LivingEntity shooter, int count);
 
     /**
      * 开始换弹时调用

--- a/src/main/java/com/tacz/guns/client/gameplay/LocalPlayerShoot.java
+++ b/src/main/java/com/tacz/guns/client/gameplay/LocalPlayerShoot.java
@@ -157,7 +157,7 @@ public class LocalPlayerShoot {
 
     private void doShoot(GunDisplayInstance display, IGun iGun, ItemStack mainHandItem, GunData gunData, long delay) {
         FireMode fireMode = iGun.getFireMode(mainHandItem);
-        //如果是全自动则按照射速应用后坐力，知道松开射击键或弹药耗尽由服务器调用stopFullAuto()
+        //如果是全自动则按照射速应用后坐力，直到松开射击键或弹药耗尽由服务器调用stopFullAuto()
         if(fireMode == FireMode.AUTO) {
             data.isShootRecorded = true;
             NetworkHandler.CHANNEL.sendToServer(new ClientMessagePlayerShootBegin(data.clientShootTimestamp - data.clientBaseTimestamp));

--- a/src/main/java/com/tacz/guns/client/gameplay/LocalPlayerShoot.java
+++ b/src/main/java/com/tacz/guns/client/gameplay/LocalPlayerShoot.java
@@ -1,5 +1,6 @@
 package com.tacz.guns.client.gameplay;
 
+import com.tacz.guns.GunMod;
 import com.tacz.guns.api.TimelessAPI;
 import com.tacz.guns.api.client.animation.statemachine.AnimationStateMachine;
 import com.tacz.guns.api.client.gameplay.IClientPlayerGunOperator;
@@ -15,12 +16,15 @@ import com.tacz.guns.client.resource.index.ClientGunIndex;
 import com.tacz.guns.client.sound.SoundPlayManager;
 import com.tacz.guns.network.NetworkHandler;
 import com.tacz.guns.network.message.ClientMessagePlayerShoot;
+import com.tacz.guns.network.message.ClientMessagePlayerShootBegin;
+import com.tacz.guns.network.message.ClientMessagePlayerShootEnd;
 import com.tacz.guns.resource.index.CommonGunIndex;
 import com.tacz.guns.resource.modifier.AttachmentCacheProperty;
 import com.tacz.guns.resource.modifier.custom.SilenceModifier;
 import com.tacz.guns.resource.pojo.data.gun.Bolt;
 import com.tacz.guns.resource.pojo.data.gun.GunData;
 import com.tacz.guns.sound.SoundManager;
+import com.tacz.guns.util.ShootBus;
 import it.unimi.dsi.fastutil.Pair;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
@@ -30,6 +34,8 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.LogicalSide;
 
 import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -39,6 +45,13 @@ public class LocalPlayerShoot {
     private static final Predicate<IGunOperator> SHOOT_LOCKED_CONDITION = operator -> operator.getSynShootCoolDown() > 0;
     private final LocalPlayerDataHolder data;
     private final LocalPlayer player;
+    private static final ScheduledExecutorService SHOOT_SCHEDULER =
+            Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r, "Gun-AutoShoot-Scheduler");
+                t.setDaemon(true);
+                return t;
+            });
+    private ScheduledFuture<?> shootTask;
 
     public LocalPlayerShoot(LocalPlayerDataHolder data, LocalPlayer player) {
         this.data = data;
@@ -144,6 +157,40 @@ public class LocalPlayerShoot {
 
     private void doShoot(GunDisplayInstance display, IGun iGun, ItemStack mainHandItem, GunData gunData, long delay) {
         FireMode fireMode = iGun.getFireMode(mainHandItem);
+        if(fireMode == FireMode.AUTO) {
+            data.isShootRecorded = true;
+            NetworkHandler.CHANNEL.sendToServer(new ClientMessagePlayerShootBegin(data.clientShootTimestamp - data.clientBaseTimestamp));
+            int rpm = iGun.getRPM(this.player.getMainHandItem());
+            double roundsPerSecond = rpm / 60.0;
+            long intervalNanos = (long) (1_000_000_000.0 / roundsPerSecond);
+            ScheduledFuture<?> task = SHOOT_SCHEDULER.scheduleAtFixedRate(
+                    () -> {
+                        Minecraft.getInstance().submitAsync(() -> {
+                            // 触发击发事件
+                            boolean fire = !MinecraftForge.EVENT_BUS.post(new GunFireEvent(player, mainHandItem, LogicalSide.CLIENT));
+                            if (fire) {
+                                // 动画和声音循环播放
+                                AnimationStateMachine<?> animationStateMachine = display.getAnimationStateMachine();
+                                if (animationStateMachine != null) {
+                                    animationStateMachine.trigger(GunAnimationConstant.INPUT_SHOOT);
+                                }
+                                // 获取消音
+                                final boolean useSilenceSound = this.useSilenceSound();
+                                // 开火需要打断检视
+                                SoundPlayManager.stopPlayGunSound(display, SoundManager.INSPECT_SOUND);
+                                if (useSilenceSound) {
+                                    SoundPlayManager.playSilenceSound(player, display, gunData);
+                                } else {
+                                    SoundPlayManager.playShootSound(player, display, gunData);
+                                }
+                            }
+                        });
+                    },
+                    0, intervalNanos, TimeUnit.NANOSECONDS
+            );
+            shootTask = task;
+            return;
+        }
         Bolt boltType = gunData.getBolt();
         // 获取余弹数
         boolean consumeAmmo = IGunOperator.fromLivingEntity(player).consumesAmmoOrNot();
@@ -216,7 +263,14 @@ public class LocalPlayerShoot {
             count.getAndIncrement();
         }, delay, period, TimeUnit.MILLISECONDS);
     }
-
+    public boolean stopFullAuto() {
+        data.isShootRecorded = true;
+        if(shootTask != null) {
+            shootTask.cancel(true);
+        }
+        NetworkHandler.CHANNEL.sendToServer(new ClientMessagePlayerShootEnd(data.clientShootTimestamp - data.clientBaseTimestamp));
+        return true;
+    }
     private boolean useSilenceSound() {
         AttachmentCacheProperty cacheProperty = IGunOperator.fromLivingEntity(player).getCacheProperty();
         if (cacheProperty != null) {

--- a/src/main/java/com/tacz/guns/client/gameplay/LocalPlayerShoot.java
+++ b/src/main/java/com/tacz/guns/client/gameplay/LocalPlayerShoot.java
@@ -157,6 +157,7 @@ public class LocalPlayerShoot {
 
     private void doShoot(GunDisplayInstance display, IGun iGun, ItemStack mainHandItem, GunData gunData, long delay) {
         FireMode fireMode = iGun.getFireMode(mainHandItem);
+        //如果是全自动则按照射速应用后坐力，知道松开射击键或弹药耗尽由服务器调用stopFullAuto()
         if(fireMode == FireMode.AUTO) {
             data.isShootRecorded = true;
             NetworkHandler.CHANNEL.sendToServer(new ClientMessagePlayerShootBegin(data.clientShootTimestamp - data.clientBaseTimestamp));

--- a/src/main/java/com/tacz/guns/client/input/ShootKey.java
+++ b/src/main/java/com/tacz/guns/client/input/ShootKey.java
@@ -71,7 +71,7 @@ public class ShootKey {
                     }
                     pushDown = true;
                 }
-            } else {
+            } else if(pushDown) {
                 operator.stopFullAuto();
                 pushDown = false;
                 lastTimeShootSuccess = false;

--- a/src/main/java/com/tacz/guns/client/input/ShootKey.java
+++ b/src/main/java/com/tacz/guns/client/input/ShootKey.java
@@ -28,6 +28,7 @@ import static com.tacz.guns.util.InputExtraCheck.isInGame;
 @OnlyIn(Dist.CLIENT)
 @Mod.EventBusSubscriber(value = Dist.CLIENT)
 public class ShootKey {
+    public static boolean pushDown = false;
     public static final KeyMapping SHOOT_KEY = new KeyMapping("key.tacz.shoot.desc",
             KeyConflictContext.IN_GAME,
             KeyModifier.NONE,
@@ -63,10 +64,16 @@ public class ShootKey {
                     // 非全自动情况，禁止连续开火
                     return;
                 }
-                if (operator.shoot() == ShootResult.SUCCESS) {
-                    lastTimeShootSuccess = true;
+                //开始全自动射击
+                if(fireMode == FireMode.AUTO && !pushDown) {
+                    if (operator.shoot() == ShootResult.SUCCESS) {
+                        lastTimeShootSuccess = true;
+                    }
+                    pushDown = true;
                 }
             } else {
+                operator.stopFullAuto();
+                pushDown = false;
                 lastTimeShootSuccess = false;
             }
         }

--- a/src/main/java/com/tacz/guns/entity/EntityKineticBullet.java
+++ b/src/main/java/com/tacz/guns/entity/EntityKineticBullet.java
@@ -331,7 +331,8 @@ public class EntityKineticBullet extends Projectile implements IEntityAdditional
                 //判断是否需要更新实体列表
                 boolean entityDestroyed = false;
                 //对于本实体包含的每一发子弹进行一次判定
-                for(int i = 0; i < bulletCount; i++) {
+                int count = bulletCount;
+                for(int i = 0; i < count; i++) {
                     if(entityDestroyed) {
                         // 子弹的击中检测，穿透为 1 或者爆炸类弹药限制为一个实体穿透判定
                         if (this.pierce <= 1 || this.explosion) {
@@ -372,9 +373,9 @@ public class EntityKineticBullet extends Projectile implements IEntityAdditional
                         if (this.pierce < 1 || this.explosion) {
                             // 子弹已经穿透所有实体，结束子弹的飞行
                             this.bulletCount--;
+                            //减少子弹数量，如果已全部消耗则清除自身
                             if(this.bulletCount == 0)
                                 this.discard();
-                            return;
                         }
                     }
                 }
@@ -615,7 +616,6 @@ public class EntityKineticBullet extends Projectile implements IEntityAdditional
         parts.core().invulnerableTime = 0;
         // 穿甲伤害
         parts.hitPart().hurt(source2, damage * armorDamagePercent);
-        GunMod.LOGGER.info("{}",damage * normalDamagePercent + damage * normalDamagePercent);
     }
 
     @Override

--- a/src/main/java/com/tacz/guns/entity/EntityKineticBullet.java
+++ b/src/main/java/com/tacz/guns/entity/EntityKineticBullet.java
@@ -128,6 +128,8 @@ public class EntityKineticBullet extends Projectile implements IEntityAdditional
     private boolean explosionKnockback = false;
     private boolean explosionDestroyBlock = false;
     private float damageModifier = 1;
+    //子弹数量（将多发子弹压入同一个实体内处理，实现超过1200的射速）
+    private int bulletCount = 1;
     // 穿透数
     private int pierce = 1;
     // 初始位置
@@ -155,17 +157,21 @@ public class EntityKineticBullet extends Projectile implements IEntityAdditional
     }
 
     public EntityKineticBullet(Level worldIn, LivingEntity throwerIn, ItemStack gunItem, ResourceLocation ammoId, ResourceLocation gunId,
-                               ResourceLocation gunDisplayId, boolean isTracerAmmo, GunData gunData, BulletData bulletData) {
-        this(TYPE, worldIn, throwerIn, gunItem, ammoId, gunId, gunDisplayId, isTracerAmmo, gunData, bulletData);
+                                    ResourceLocation gunDisplayId, boolean isTracerAmmo, GunData gunData, BulletData bulletData) {
+        this(TYPE, worldIn, throwerIn, gunItem, ammoId, gunId, gunDisplayId, isTracerAmmo, gunData, bulletData, 1);
+    }
+    public EntityKineticBullet(Level worldIn, LivingEntity throwerIn, ItemStack gunItem, ResourceLocation ammoId, ResourceLocation gunId,
+                               ResourceLocation gunDisplayId, boolean isTracerAmmo, GunData gunData, BulletData bulletData, int bulletCount) {
+        this(TYPE, worldIn, throwerIn, gunItem, ammoId, gunId, gunDisplayId, isTracerAmmo, gunData, bulletData, bulletCount);
     }
 
     public EntityKineticBullet(Level worldIn, LivingEntity throwerIn, ItemStack gunItem, ResourceLocation ammoId, ResourceLocation gunId, boolean isTracerAmmo, GunData gunData, BulletData bulletData) {
-        this(TYPE, worldIn, throwerIn, gunItem, ammoId, gunId, DefaultAssets.DEFAULT_GUN_DISPLAY_ID, isTracerAmmo, gunData, bulletData);
+        this(TYPE, worldIn, throwerIn, gunItem, ammoId, gunId, DefaultAssets.DEFAULT_GUN_DISPLAY_ID, isTracerAmmo, gunData, bulletData, 1);
     }
 
     protected EntityKineticBullet(EntityType<? extends Projectile> type, Level worldIn, LivingEntity throwerIn, ItemStack gunItem,
                                   ResourceLocation ammoId, ResourceLocation gunId, ResourceLocation gunDisplayId,
-                                  boolean isTracerAmmo, GunData gunData, BulletData bulletData) {
+                                  boolean isTracerAmmo, GunData gunData, BulletData bulletData, int bulletCount) {
         this(type, throwerIn.getX(), throwerIn.getEyeY() - (double) 0.1F, throwerIn.getZ(), worldIn);
         this.setOwner(throwerIn);
         // gunId 提前赋值，以让 modifyProperty 可以在构造函数中运行
@@ -190,6 +196,7 @@ public class EntityKineticBullet extends Projectile implements IEntityAdditional
         this.igniteBlock = modifyProperty(IGNITE_BLOCK, Boolean.class, bulletData.getIgnite().isIgniteBlock() || ignite.isIgniteBlock());
         this.damageAmount = cacheProperty.getCache(DamageModifier.ID);
         this.distanceAmount = modifyProperty(GunProperties.EFFECTIVE_RANGE, Float.class, cacheProperty.getCache(GunProperties.EFFECTIVE_RANGE));
+        this.bulletCount = bulletCount;
         int pierce = modifyProperty(GunProperties.PIERCE, Integer.class, cacheProperty.getCache(GunProperties.PIERCE));
         this.pierce = Mth.clamp(pierce, 1, Integer.MAX_VALUE);
         ExplosionData explosionData = Objects.requireNonNullElse(cacheProperty.getCache(ExplosionModifier.ID), DEFAULT_EXPLOSION_DATA);
@@ -321,27 +328,54 @@ public class EntityKineticBullet extends Projectile implements IEntityAdditional
             }
             // 当子弹击中实体时，进行被命中的实体读取
             if (hitEntities != null && !hitEntities.isEmpty()) {
-                EntityResult[] hitEntityResult = hitEntities.toArray(new EntityResult[0]);
-                // 对被命中的实体进行排序，按照距离子弹发射位置的距离进行升序排序
-                for (int i = 0; (i < this.pierce || i < 1) && i < (hitEntityResult.length - 1); i++) {
-                    int k = i;
-                    for (int j = i + 1; j < hitEntityResult.length; j++) {
-                        if (hitEntityResult[j].hitVec.distanceTo(startVec) < hitEntityResult[k].hitVec.distanceTo(startVec)) {
-                            k = j;
+                //判断是否需要更新实体列表
+                boolean entityDestroyed = false;
+                //对于本实体包含的每一发子弹进行一次判定
+                for(int i = 0; i < bulletCount; i++) {
+                    if(entityDestroyed) {
+                        // 子弹的击中检测，穿透为 1 或者爆炸类弹药限制为一个实体穿透判定
+                        if (this.pierce <= 1 || this.explosion) {
+                            EntityResult entityResult = EntityUtil.findEntityOnPath(this, startVec, endVec);
+                            // 将单个命中是实体创建为单个内容的 list
+                            if (entityResult != null) {
+                                hitEntities = Collections.singletonList(entityResult);
+                            }
+                        } else {
+                            hitEntities = EntityUtil.findEntitiesOnPath(this, startVec, endVec);
+                        }
+                        //判断是否还有实体
+                        if (hitEntities.isEmpty()) {
+                            break;
                         }
                     }
-                    EntityResult t = hitEntityResult[i];
-                    hitEntityResult[i] = hitEntityResult[k];
-                    hitEntityResult[k] = t;
-                }
-                for (EntityResult entityResult : hitEntityResult) {
-                    result = new TacHitResult(entityResult);
-                    this.onHitEntity((TacHitResult) result, startVec, endVec);
-                    this.pierce--;
-                    if (this.pierce < 1 || this.explosion) {
-                        // 子弹已经穿透所有实体，结束子弹的飞行
-                        this.discard();
-                        return;
+                    EntityResult[] hitEntityResult = hitEntities.toArray(new EntityResult[0]);
+                    // 对被命中的实体进行排序，按照距离子弹发射位置的距离进行升序排序
+                    for (int j = 0; (i < this.pierce || j < 1) && j < (hitEntityResult.length - 1); j++) {
+                        int l = j;
+                        for (int k = j + 1; k < hitEntityResult.length; k++) {
+                            if (hitEntityResult[k].hitVec.distanceTo(startVec) < hitEntityResult[l].hitVec.distanceTo(startVec)) {
+                                l = k;
+                            }
+                        }
+                        EntityResult t = hitEntityResult[j];
+                        hitEntityResult[j] = hitEntityResult[l];
+                        hitEntityResult[l] = t;
+                    }
+                    for (EntityResult entityResult : hitEntityResult) {
+                        result = new TacHitResult(entityResult);
+                        String hitResult = this.onHitEntity((TacHitResult) result, startVec, endVec);
+                        if(Objects.equals(hitResult, "DEAD")) {
+                            entityDestroyed = true;
+                        }
+
+                        this.pierce--;
+                        if (this.pierce < 1 || this.explosion) {
+                            // 子弹已经穿透所有实体，结束子弹的飞行
+                            this.bulletCount--;
+                            if(this.bulletCount == 0)
+                                this.discard();
+                            return;
+                        }
                     }
                 }
             }
@@ -383,12 +417,12 @@ public class EntityKineticBullet extends Projectile implements IEntityAdditional
         }
     }
 
-    protected void onHitEntity(TacHitResult result, Vec3 startVec, Vec3 endVec) {
+    protected String onHitEntity(TacHitResult result, Vec3 startVec, Vec3 endVec) {
         if (result.getEntity() instanceof ITargetEntity targetEntity) {
             DamageSource source = this.damageSources().thrown(this, this.getOwner());
             targetEntity.onProjectileHit(this, result, source, this.getDamage(result.getLocation()));
             // 打靶直接返回
-            return;
+            return "SHOT_TARGET";
         }
         // 获取Pre事件必要的信息
         Entity entity = result.getEntity();
@@ -403,7 +437,7 @@ public class EntityKineticBullet extends Projectile implements IEntityAdditional
         var preEvent = new EntityHurtByGunEvent.Pre(this, entity, attacker, this.gunId, this.gunDisplayId, damage, sources, headshot, headShotMultiplier, LogicalSide.SERVER);
         var cancelled = MinecraftForge.EVENT_BUS.post(preEvent);
         if (cancelled) {
-            return;
+            return "CANCELLED";
         }
         // 刷新由Pre事件修改后的参数
         entity = preEvent.getHurtEntity();
@@ -416,7 +450,7 @@ public class EntityKineticBullet extends Projectile implements IEntityAdditional
         headshot = preEvent.isHeadShot();
         headShotMultiplier = preEvent.getHeadshotMultiplier();
         if (entity == null) {
-            return;
+            return "NOT_HIT";
         }
         // 点燃
         if (this.igniteEntity && AmmoConfig.IGNITE_ENTITY.get()) {
@@ -459,12 +493,15 @@ public class EntityKineticBullet extends Projectile implements IEntityAdditional
                 if (livingCore.isDeadOrDying()) {
                     MinecraftForge.EVENT_BUS.post(new EntityKillByGunEvent(this, livingCore, attacker, newGunId, gunDisplayId, damage, sources, headshot, headShotMultiplier, LogicalSide.SERVER));
                     NetworkHandler.sendToDimension(new ServerMessageGunKill(getId(), livingCore.getId(), attackerId, newGunId, gunDisplayId, damage, headshot, headShotMultiplier), livingCore);
+                    return "DEAD";
                 } else {
                     MinecraftForge.EVENT_BUS.post(new EntityHurtByGunEvent.Post(this, livingCore, attacker, newGunId, gunDisplayId, damage, sources, headshot, headShotMultiplier, LogicalSide.SERVER));
                     NetworkHandler.sendToDimension(new ServerMessageGunHurt(getId(), livingCore.getId(), attackerId, newGunId, gunDisplayId, damage, headshot, headShotMultiplier), livingCore);
+                    return "ALIVE";
                 }
             }
         }
+        return "UNKNOWN";
     }
 
     protected void onHitBlock(BlockHitResult result, Vec3 startVec, Vec3 endVec) {
@@ -578,6 +615,7 @@ public class EntityKineticBullet extends Projectile implements IEntityAdditional
         parts.core().invulnerableTime = 0;
         // 穿甲伤害
         parts.hitPart().hurt(source2, damage * armorDamagePercent);
+        GunMod.LOGGER.info("{}",damage * normalDamagePercent + damage * normalDamagePercent);
     }
 
     @Override

--- a/src/main/java/com/tacz/guns/entity/shooter/LivingEntityShoot.java
+++ b/src/main/java/com/tacz/guns/entity/shooter/LivingEntityShoot.java
@@ -1,6 +1,5 @@
 package com.tacz.guns.entity.shooter;
 
-import com.tacz.guns.GunMod;
 import com.tacz.guns.api.TimelessAPI;
 import com.tacz.guns.api.entity.IGunOperator;
 import com.tacz.guns.api.entity.ShootResult;
@@ -34,7 +33,6 @@ import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 public class LivingEntityShoot {
@@ -172,19 +170,14 @@ public class LivingEntityShoot {
         UUID playerUuid = this.shooter.getUUID();
         if(this.shooter.getMainHandItem().getItem() instanceof IGun iGun) {
             int rpm = iGun.getRPM(this.shooter.getMainHandItem());
-            double roundsPerSecond = rpm / 60.0;
-            long intervalNanos = (long) (1_000_000_000.0 / roundsPerSecond);
-            ScheduledFuture<?> task = SHOOT_SCHEDULER.scheduleAtFixedRate(
-                    () -> ShootBus.addShot(playerUuid),
-                    0, intervalNanos, TimeUnit.NANOSECONDS
-            );
-            shootTask = task;
+            ShootBus.beginShot(playerUuid, rpm);
             return true;
         }
         return false;
     }
-    public boolean stopFullAuto() {
-        return shootTask.cancel(true);
+    public void stopFullAuto() {
+        UUID playerUuid = this.shooter.getUUID();
+        ShootBus.endShot(playerUuid);
     }
     /**
      * 以当前时间戳查询射击冷却。返回值一般不会超过枪械的射击间隔

--- a/src/main/java/com/tacz/guns/entity/shooter/LivingEntityShoot.java
+++ b/src/main/java/com/tacz/guns/entity/shooter/LivingEntityShoot.java
@@ -1,5 +1,6 @@
 package com.tacz.guns.entity.shooter;
 
+import com.tacz.guns.GunMod;
 import com.tacz.guns.api.TimelessAPI;
 import com.tacz.guns.api.entity.IGunOperator;
 import com.tacz.guns.api.entity.ShootResult;
@@ -13,6 +14,7 @@ import com.tacz.guns.network.message.ServerMessageSyncBaseTimestamp;
 import com.tacz.guns.network.message.event.ServerMessageGunShoot;
 import com.tacz.guns.resource.index.CommonGunIndex;
 import com.tacz.guns.resource.pojo.data.gun.Bolt;
+import com.tacz.guns.util.ShootBus;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
@@ -25,20 +27,31 @@ import net.minecraftforge.network.PacketDistributor;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 public class LivingEntityShoot {
     private final LivingEntity shooter;
     private final ShooterDataHolder data;
     private final LivingEntityDrawGun draw;
-
+    private static final ScheduledExecutorService SHOOT_SCHEDULER =
+            Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r, "Gun-AutoShoot-Scheduler");
+                t.setDaemon(true);
+                return t;
+            });
+    private ScheduledFuture<?> shootTask;
     public LivingEntityShoot(LivingEntity shooter, ShooterDataHolder data, LivingEntityDrawGun draw) {
         this.shooter = shooter;
         this.data = data;
         this.draw = draw;
     }
 
-    public ShootResult shoot(Supplier<Float> pitch, Supplier<Float> yaw, long timestamp) {
+    public ShootResult shoot(Supplier<Float> pitch, Supplier<Float> yaw, long timestamp, int count, boolean fromServer) {
         if (data.currentGunItem == null) {
             return ShootResult.NOT_DRAW;
         }
@@ -63,7 +76,7 @@ public class LivingEntityShoot {
                 return ShootResult.COOL_DOWN;
             }
         }
-        if (SyncConfig.SERVER_SHOOT_NETWORK_V.get()) {
+        if (SyncConfig.SERVER_SHOOT_NETWORK_V.get() && !fromServer) {
             // 根据 tick time 和 允许的网络延迟波动 计算 时间戳的接受窗口
             MinecraftServer server = Objects.requireNonNull(shooter.getServer());
             double tickTime = Math.max(server.tickTimes[server.getTickCount() % 100] * 1.0E-6D, 50);
@@ -138,11 +151,28 @@ public class LivingEntityShoot {
         data.shootTimestamp = timestamp;
         // 执行枪械射击逻辑
         if (iGun instanceof AbstractGunItem logicGun) {
-            logicGun.shoot(data, currentGunItem, pitch, yaw, shooter);
+            logicGun.shoot(data, currentGunItem, pitch, yaw, shooter, count);
         }
         return ShootResult.SUCCESS;
     }
-
+    public boolean startFullAuto(long timestamp) {
+        UUID playerUuid = this.shooter.getUUID();
+        if(this.shooter.getMainHandItem().getItem() instanceof IGun iGun) {
+            int rpm = iGun.getRPM(this.shooter.getMainHandItem());
+            double roundsPerSecond = rpm / 60.0;
+            long intervalNanos = (long) (1_000_000_000.0 / roundsPerSecond);
+            ScheduledFuture<?> task = SHOOT_SCHEDULER.scheduleAtFixedRate(
+                    () -> ShootBus.addShot(playerUuid),
+                    0, intervalNanos, TimeUnit.NANOSECONDS
+            );
+            shootTask = task;
+            return true;
+        }
+        return false;
+    }
+    public boolean stopFullAuto(long timestamp) {
+        return shootTask.cancel(true);
+    }
     /**
      * 以当前时间戳查询射击冷却。返回值一般不会超过枪械的射击间隔
      * @return 射击冷却

--- a/src/main/java/com/tacz/guns/entity/shooter/LivingEntityShoot.java
+++ b/src/main/java/com/tacz/guns/entity/shooter/LivingEntityShoot.java
@@ -9,6 +9,7 @@ import com.tacz.guns.api.item.IGun;
 import com.tacz.guns.api.item.gun.AbstractGunItem;
 import com.tacz.guns.api.item.gun.FireMode;
 import com.tacz.guns.config.sync.SyncConfig;
+import com.tacz.guns.item.ModernKineticGunScriptAPI;
 import com.tacz.guns.network.NetworkHandler;
 import com.tacz.guns.network.message.ServerMessageGunStop;
 import com.tacz.guns.network.message.ServerMessageSyncBaseTimestamp;
@@ -155,10 +156,15 @@ public class LivingEntityShoot {
         if (iGun instanceof AbstractGunItem logicGun) {
             logicGun.shoot(data, currentGunItem, pitch, yaw, shooter, count);
         }
-        if(((IGun)shooter.getMainHandItem().getItem()).getFireMode(shooter.getMainHandItem()) == FireMode.AUTO &&
-                ((IGun)shooter.getMainHandItem().getItem()).getCurrentAmmoCount(shooter.getMainHandItem()) <= 0 &&
-                !((IGun)shooter.getMainHandItem().getItem()).hasBulletInBarrel(shooter.getMainHandItem())) {
-            NetworkHandler.sendToClientPlayer(new ServerMessageGunStop(shooter.getId()), (Player) shooter);
+        if(((IGun)shooter.getMainHandItem().getItem()).getFireMode(shooter.getMainHandItem()) == FireMode.AUTO) {
+            ModernKineticGunScriptAPI api = new ModernKineticGunScriptAPI();
+            api.setItemStack(currentGunItem);
+            api.setShooter(shooter);
+            api.setDataHolder(data);
+            api.setPitchSupplier(pitch);
+            api.setYawSupplier(yaw);
+            if(!api.reduceAmmoOnce(true))
+                NetworkHandler.sendToClientPlayer(new ServerMessageGunStop(shooter.getId()), (Player) shooter);
         }
         return ShootResult.SUCCESS;
     }

--- a/src/main/java/com/tacz/guns/entity/shooter/LivingEntityShoot.java
+++ b/src/main/java/com/tacz/guns/entity/shooter/LivingEntityShoot.java
@@ -10,6 +10,7 @@ import com.tacz.guns.api.item.gun.AbstractGunItem;
 import com.tacz.guns.api.item.gun.FireMode;
 import com.tacz.guns.config.sync.SyncConfig;
 import com.tacz.guns.network.NetworkHandler;
+import com.tacz.guns.network.message.ServerMessageGunStop;
 import com.tacz.guns.network.message.ServerMessageSyncBaseTimestamp;
 import com.tacz.guns.network.message.event.ServerMessageGunShoot;
 import com.tacz.guns.resource.index.CommonGunIndex;
@@ -19,6 +20,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
@@ -77,7 +79,7 @@ public class LivingEntityShoot {
             }
         }
         if (SyncConfig.SERVER_SHOOT_NETWORK_V.get() && !fromServer) {
-            // 根据 tick time 和 允许的网络延迟波动 计算 时间戳的接受窗口
+            // 根据 tick time 和 允许的网络延迟波动 计算 时间戳的接受窗口 如果来自服务器则无需计算窗口可直接使用
             MinecraftServer server = Objects.requireNonNull(shooter.getServer());
             double tickTime = Math.max(server.tickTimes[server.getTickCount() % 100] * 1.0E-6D, 50);
             long alpha = System.currentTimeMillis() - data.baseTimestamp - timestamp;
@@ -153,6 +155,11 @@ public class LivingEntityShoot {
         if (iGun instanceof AbstractGunItem logicGun) {
             logicGun.shoot(data, currentGunItem, pitch, yaw, shooter, count);
         }
+        if(((IGun)shooter.getMainHandItem().getItem()).getFireMode(shooter.getMainHandItem()) == FireMode.AUTO &&
+                ((IGun)shooter.getMainHandItem().getItem()).getCurrentAmmoCount(shooter.getMainHandItem()) <= 0 &&
+                !((IGun)shooter.getMainHandItem().getItem()).hasBulletInBarrel(shooter.getMainHandItem())) {
+            NetworkHandler.sendToClientPlayer(new ServerMessageGunStop(shooter.getId()), (Player) shooter);
+        }
         return ShootResult.SUCCESS;
     }
     public boolean startFullAuto(long timestamp) {
@@ -170,7 +177,7 @@ public class LivingEntityShoot {
         }
         return false;
     }
-    public boolean stopFullAuto(long timestamp) {
+    public boolean stopFullAuto() {
         return shootTask.cancel(true);
     }
     /**

--- a/src/main/java/com/tacz/guns/item/ModernKineticGunItem.java
+++ b/src/main/java/com/tacz/guns/item/ModernKineticGunItem.java
@@ -97,7 +97,7 @@ public class ModernKineticGunItem extends AbstractGunItem implements GunItemData
     }
 
     @Override
-    public void shoot(ShooterDataHolder dataHolder, ItemStack gunItem, Supplier<Float> pitch, Supplier<Float> yaw, LivingEntity shooter) {
+    public void shoot(ShooterDataHolder dataHolder, ItemStack gunItem, Supplier<Float> pitch, Supplier<Float> yaw, LivingEntity shooter, int count) {
         ModernKineticGunScriptAPI api = new ModernKineticGunScriptAPI();
         api.setItemStack(gunItem);
         api.setShooter(shooter);
@@ -114,7 +114,7 @@ public class ModernKineticGunItem extends AbstractGunItem implements GunItemData
                 .map(script -> checkFunction(script.get("shoot")))
                 .ifPresentOrElse(
                         func -> func.call(CoerceJavaToLua.coerce(api)),
-                        ()   -> api.shootOnce(api.isShootingNeedConsumeAmmo()));
+                        ()   -> api.shootOnce(api.isShootingNeedConsumeAmmo(), count));
     }
 
     @Override

--- a/src/main/java/com/tacz/guns/item/ModernKineticGunScriptAPI.java
+++ b/src/main/java/com/tacz/guns/item/ModernKineticGunScriptAPI.java
@@ -1,5 +1,6 @@
 package com.tacz.guns.item;
 
+import com.tacz.guns.GunMod;
 import com.tacz.guns.api.DefaultAssets;
 import com.tacz.guns.api.GunProperties;
 import com.tacz.guns.api.GunProperty;
@@ -8,6 +9,7 @@ import com.tacz.guns.api.entity.IGunOperator;
 import com.tacz.guns.api.event.common.GunFireEvent;
 import com.tacz.guns.api.item.IAmmo;
 import com.tacz.guns.api.item.IAmmoBox;
+import com.tacz.guns.api.item.IGun;
 import com.tacz.guns.api.item.attachment.AttachmentType;
 import com.tacz.guns.api.item.gun.AbstractGunItem;
 import com.tacz.guns.api.item.gun.FireMode;
@@ -98,7 +100,7 @@ public class ModernKineticGunScriptAPI {
      * 执行一次完整的射击逻辑，会考虑玩家的状态(是否在瞄准、是否在移动、是否在匍匐等)、配件数值影响、多弹丸散射、连发，播放开火音效、
      * @param consumeAmmo 本次射击是否消耗弹药
      */
-    public void shootOnce(boolean consumeAmmo){
+    public void shootOnce(boolean consumeAmmo, int count) {
         GunData gunData = gunIndex.getGunData();
         BulletData bulletData = gunIndex.getBulletData();
         IGunOperator gunOperator = IGunOperator.fromLivingEntity(shooter);
@@ -143,6 +145,7 @@ public class ModernKineticGunScriptAPI {
         long period = modifyProperty(GunProperties.RuntimeOnly.BURST_SHOOT_INTERVAL, Long.class, fireMode == FireMode.BURST ? gunData.getBurstShootInterval() : 1);
 
         CycleTaskHelper.addCycleTask(() -> {
+            int bulletCount = count;
             // 如果射击者死亡，取消射击
             if (shooter.isDeadOrDying()) {
                 return false;
@@ -155,9 +158,24 @@ public class ModernKineticGunScriptAPI {
             boolean fire = !MinecraftForge.EVENT_BUS.post(new GunFireEvent(shooter, itemStack, LogicalSide.SERVER));
             if (fire) {
                 NetworkHandler.sendToTrackingEntity(new ServerMessageGunFire(shooter.getId(), itemStack), shooter);
+                {
+                    IGun gun = IGun.getIGunOrNull(shooter.getMainHandItem());
+                    GunMod.LOGGER.info("{} {}", gun.getCurrentAmmoCount(shooter.getMainHandItem()), bulletCount);
+                    if (gun.getCurrentAmmoCount(shooter.getMainHandItem()) < bulletCount) {
+                        GunMod.LOGGER.warn("FUCK!!!!");
+                    }
+                }
                 // 削减弹药
                 if (consumeAmmo) {
-                    if (!this.reduceAmmoOnce()) {
+                    int i = bulletCount;
+                    while (i > 0) {
+                        if (!this.reduceAmmoOnce()) {
+                            bulletCount -= i;
+                            break;
+                        }
+                        i-=1;
+                    }
+                    if(bulletCount <= 0) {
                         return false;
                     }
                 }
@@ -179,7 +197,7 @@ public class ModernKineticGunScriptAPI {
                 for (int i = 0; i < bulletAmount; i++) {
                     boolean isTracer = bulletData.hasTracerAmmo() && gunOperator.nextBulletIsTracer(bulletData.getTracerCountInterval());
                     EntityKineticBullet bullet = new EntityKineticBullet(world, shooter, itemStack, ammoId, gunId,
-                            gunDisplayId, isTracer, gunData, bulletData);
+                            gunDisplayId, isTracer, gunData, bulletData, bulletCount);
                     bullet.applyShotgunDamageSpread(bulletAmount);
                     abstractGunItem.doBulletSpread(dataHolder, itemStack, shooter, bullet, i, processedSpeed,
                             inaccuracy, pitch, yaw);

--- a/src/main/java/com/tacz/guns/item/ModernKineticGunScriptAPI.java
+++ b/src/main/java/com/tacz/guns/item/ModernKineticGunScriptAPI.java
@@ -104,6 +104,7 @@ public class ModernKineticGunScriptAPI {
      * @param consumeAmmo 本次射击是否消耗弹药
      */
     public void shootOnce(boolean consumeAmmo, int count) {
+        GunMod.LOGGER.info("{}", count);
         GunData gunData = gunIndex.getGunData();
         BulletData bulletData = gunIndex.getBulletData();
         IGunOperator gunOperator = IGunOperator.fromLivingEntity(shooter);
@@ -279,7 +280,9 @@ public class ModernKineticGunScriptAPI {
                     return consumeAmmoFromPlayer(1, simulate) == 1;
                 }
                 // 如果非背包直读则弹匣内子弹 - 1
-                abstractGunItem.reduceCurrentAmmoCount(itemStack);
+                if(!simulate) {
+                    abstractGunItem.reduceCurrentAmmoCount(itemStack);
+                }
                 return true;
             }
             // 没有膛内子弹无法射击

--- a/src/main/java/com/tacz/guns/item/ModernKineticGunScriptAPI.java
+++ b/src/main/java/com/tacz/guns/item/ModernKineticGunScriptAPI.java
@@ -21,6 +21,7 @@ import com.tacz.guns.entity.EntityKineticBullet;
 import com.tacz.guns.entity.shooter.ShooterDataHolder;
 import com.tacz.guns.network.NetworkHandler;
 import com.tacz.guns.network.message.event.ServerMessageGunFire;
+import com.tacz.guns.network.message.ServerMessageGunStop;
 import com.tacz.guns.resource.index.CommonGunIndex;
 import com.tacz.guns.resource.modifier.AttachmentCacheProperty;
 import com.tacz.guns.resource.modifier.custom.SilenceModifier;
@@ -32,11 +33,13 @@ import it.unimi.dsi.fastutil.Pair;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.fml.LogicalSide;
+import org.antlr.v4.parse.ANTLRParser;
 import org.luaj.vm2.LuaError;
 import org.luaj.vm2.LuaFunction;
 import org.luaj.vm2.LuaTable;
@@ -158,13 +161,6 @@ public class ModernKineticGunScriptAPI {
             boolean fire = !MinecraftForge.EVENT_BUS.post(new GunFireEvent(shooter, itemStack, LogicalSide.SERVER));
             if (fire) {
                 NetworkHandler.sendToTrackingEntity(new ServerMessageGunFire(shooter.getId(), itemStack), shooter);
-                {
-                    IGun gun = IGun.getIGunOrNull(shooter.getMainHandItem());
-                    GunMod.LOGGER.info("{} {}", gun.getCurrentAmmoCount(shooter.getMainHandItem()), bulletCount);
-                    if (gun.getCurrentAmmoCount(shooter.getMainHandItem()) < bulletCount) {
-                        GunMod.LOGGER.warn("FUCK!!!!");
-                    }
-                }
                 // 削减弹药
                 if (consumeAmmo) {
                     int i = bulletCount;

--- a/src/main/java/com/tacz/guns/item/ModernKineticGunScriptAPI.java
+++ b/src/main/java/com/tacz/guns/item/ModernKineticGunScriptAPI.java
@@ -166,7 +166,7 @@ public class ModernKineticGunScriptAPI {
                     int i = bulletCount;
                     while (i > 0) {
                         if (!this.reduceAmmoOnce()) {
-                            bulletCount -= i;
+                            bulletCount = 0;
                             break;
                         }
                         i-=1;
@@ -231,13 +231,22 @@ public class ModernKineticGunScriptAPI {
             abstractGunItem.setOverheatLocked(itemStack, true);
         }
     }
-
     /**
      * 让枪械内的子弹减少一发。会遵从栓动、闭膛待击和开膛待机的规律，消耗枪管内子弹或者弹匣内子弹。
-     * 如果没有可以消耗的子弹，这个方法会返回 false。例如栓动步枪，虽然弹匣内有子弹，但是在 bolt 之前枪管内没有子弹，那么就会返回 false，
+     *
      * @return 是否成功减少子弹。
      */
     public boolean reduceAmmoOnce() {
+        return  reduceAmmoOnce(false);
+    }
+    /**
+     * 让枪械内的子弹减少一发。会遵从栓动、闭膛待击和开膛待机的规律，消耗枪管内子弹或者弹匣内子弹。
+     *
+     * @param simulate 如果为 {@code true}，则仅测试是否可以消耗子弹，不实际修改数量；
+     *                 如果为 {@code false}，则真实消耗子弹。
+     * @return 是否成功减少子弹（或是否可以减少）。
+     */
+    public boolean reduceAmmoOnce(boolean simulate) {
         Bolt boltType = TimelessAPI.getCommonGunIndex(abstractGunItem.getGunId(itemStack))
                 .map(index -> index.getGunData().getBolt())
                 .orElse(null);
@@ -267,7 +276,7 @@ public class ModernKineticGunScriptAPI {
             if (!noAmmo) {
                 // 如果背包直读则背包内射击后弹药 - 1
                 if (useInventoryAmmo()) {
-                    return consumeAmmoFromPlayer(1) == 1;
+                    return consumeAmmoFromPlayer(1, simulate) == 1;
                 }
                 // 如果非背包直读则弹匣内子弹 - 1
                 abstractGunItem.reduceCurrentAmmoCount(itemStack);
@@ -278,7 +287,9 @@ public class ModernKineticGunScriptAPI {
                 return false;
             }
             // 没有弹匣内的子弹则消耗枪膛内的子弹
-            abstractGunItem.setBulletInBarrel(itemStack, false);
+            if(!simulate) {
+                abstractGunItem.setBulletInBarrel(itemStack, false);
+            }
             return true;
         }
         // 开膛逻辑
@@ -289,15 +300,18 @@ public class ModernKineticGunScriptAPI {
             }
             // 如果背包直读则背包内射击后弹药 - 1
             if (useInventoryAmmo()) {
-                return consumeAmmoFromPlayer(1) == 1;
+                return consumeAmmoFromPlayer(1, simulate) == 1;
             }
             // 如果非背包直读则弹匣内子弹 - 1
-            abstractGunItem.reduceCurrentAmmoCount(itemStack);
+            if(!simulate) {
+                abstractGunItem.reduceCurrentAmmoCount(itemStack);
+            }
             return true;
         }
         // 非三种已知 Bolt 类型 (目前不会出现)，默认返回 false
         return false;
     }
+
 
     /**
      * 获取从开始换弹到现在经历的时间，单位为 ms
@@ -462,7 +476,6 @@ public class ModernKineticGunScriptAPI {
     public int getMagExtentLevel() {
         return AttachmentDataUtils.getMagExtendLevel(itemStack, gunIndex.getGunData());
     }
-
     /**
      * 尽可能多地从玩家身上 (或者虚拟备弹) 消耗掉弹药，返回消耗的数量
      *
@@ -470,6 +483,17 @@ public class ModernKineticGunScriptAPI {
      * @return 实际消耗的弹药数量
      */
     public int consumeAmmoFromPlayer(int neededAmount) {
+        return consumeAmmoFromPlayer(neededAmount, false);
+    }
+    /**
+     * 尽可能多地从玩家身上 (或者虚拟备弹) 消耗掉弹药，返回消耗的数量
+     *
+     * @param neededAmount 需要的弹药数量
+     * @param simulate 如果为 {@code true}，则仅测试是否可以消耗子弹，不实际修改数量；
+     *                 如果为 {@code false}，则真实消耗子弹。
+     * @return 实际消耗的弹药数量
+     */
+    public int consumeAmmoFromPlayer(int neededAmount, boolean simulate) {
         // 如果处于背包直读并且创造模式不消耗的情况
         if (useInventoryAmmo() && !isReloadingNeedConsumeAmmo()) {
             return neededAmount;
@@ -478,7 +502,7 @@ public class ModernKineticGunScriptAPI {
             return abstractGunItem.findAndExtractDummyAmmo(itemStack, neededAmount);
         } else {
             return shooter.getCapability(ForgeCapabilities.ITEM_HANDLER, null)
-                    .map(cap -> abstractGunItem.findAndExtractInventoryAmmo(cap, itemStack, neededAmount))
+                    .map(cap -> abstractGunItem.findAndExtractInventoryAmmo(cap, itemStack, 1, true))
                     .orElse(0);
         }
     }

--- a/src/main/java/com/tacz/guns/mixin/client/LocalPlayerMixin.java
+++ b/src/main/java/com/tacz/guns/mixin/client/LocalPlayerMixin.java
@@ -38,8 +38,8 @@ public abstract class LocalPlayerMixin implements IClientPlayerGunOperator {
 
     @Unique
     @Override
-    public boolean stopFullAuto() {
-        return tac$shoot.stopFullAuto();
+    public void stopFullAuto() {
+        tac$shoot.stopFullAuto();
     }
 
     @Unique

--- a/src/main/java/com/tacz/guns/mixin/client/LocalPlayerMixin.java
+++ b/src/main/java/com/tacz/guns/mixin/client/LocalPlayerMixin.java
@@ -38,6 +38,12 @@ public abstract class LocalPlayerMixin implements IClientPlayerGunOperator {
 
     @Unique
     @Override
+    public boolean stopFullAuto() {
+        return tac$shoot.stopFullAuto();
+    }
+
+    @Unique
+    @Override
     public void draw(ItemStack lastItem) {
         tac$draw.draw(lastItem);
     }

--- a/src/main/java/com/tacz/guns/mixin/common/LivingEntityMixin.java
+++ b/src/main/java/com/tacz/guns/mixin/common/LivingEntityMixin.java
@@ -140,7 +140,24 @@ public abstract class LivingEntityMixin extends Entity implements IGunOperator, 
     @Unique
     @Override
     public ShootResult shoot(Supplier<Float> pitch, Supplier<Float> yaw, long timestamp) {
-        return tacz$shoot.shoot(pitch, yaw, timestamp);
+        return this.shoot(pitch, yaw, timestamp, 1, false);
+    }
+    @Unique
+    @Override
+    public ShootResult shoot(Supplier<Float> pitch, Supplier<Float> yaw, long timestamp, int count, boolean source) {
+        return tacz$shoot.shoot(pitch, yaw, timestamp, count, source);
+    }
+
+    @Unique
+    @Override
+    public boolean startFullAuto(long timestamp) {
+        return tacz$shoot.startFullAuto(timestamp);
+    }
+
+    @Unique
+    @Override
+    public boolean stopFullAuto(long timestamp) {
+        return tacz$shoot.stopFullAuto(timestamp);
     }
 
     @Unique

--- a/src/main/java/com/tacz/guns/mixin/common/LivingEntityMixin.java
+++ b/src/main/java/com/tacz/guns/mixin/common/LivingEntityMixin.java
@@ -150,14 +150,14 @@ public abstract class LivingEntityMixin extends Entity implements IGunOperator, 
 
     @Unique
     @Override
-    public boolean startFullAuto(long timestamp) {
-        return tacz$shoot.startFullAuto(timestamp);
+    public void startFullAuto(long timestamp) {
+        tacz$shoot.startFullAuto(timestamp);
     }
 
     @Unique
     @Override
-    public boolean stopFullAuto(long timestamp) {
-        return tacz$shoot.stopFullAuto(timestamp);
+    public void stopFullAuto() {
+        tacz$shoot.stopFullAuto();
     }
 
     @Unique

--- a/src/main/java/com/tacz/guns/network/NetworkHandler.java
+++ b/src/main/java/com/tacz/guns/network/NetworkHandler.java
@@ -43,6 +43,8 @@ public class NetworkHandler {
                 Optional.of(NetworkDirection.PLAY_TO_SERVER));
         CHANNEL.registerMessage(ID_COUNT.getAndIncrement(), ClientMessagePlayerShootEnd.class, ClientMessagePlayerShootEnd::encode, ClientMessagePlayerShootEnd::decode, ClientMessagePlayerShootEnd::handle,
                 Optional.of(NetworkDirection.PLAY_TO_SERVER));
+        CHANNEL.registerMessage(ID_COUNT.getAndIncrement(), ServerMessageGunStop.class, ServerMessageGunStop::encode, ServerMessageGunStop::decode, ServerMessageGunStop::handle,
+                Optional.of(NetworkDirection.PLAY_TO_CLIENT));
         CHANNEL.registerMessage(ID_COUNT.getAndIncrement(), ClientMessagePlayerReloadGun.class, ClientMessagePlayerReloadGun::encode, ClientMessagePlayerReloadGun::decode, ClientMessagePlayerReloadGun::handle,
                 Optional.of(NetworkDirection.PLAY_TO_SERVER));
         CHANNEL.registerMessage(ID_COUNT.getAndIncrement(), ClientMessagePlayerCancelReload.class, ClientMessagePlayerCancelReload::encode, ClientMessagePlayerCancelReload::decode, ClientMessagePlayerCancelReload::handle,

--- a/src/main/java/com/tacz/guns/network/NetworkHandler.java
+++ b/src/main/java/com/tacz/guns/network/NetworkHandler.java
@@ -39,6 +39,10 @@ public class NetworkHandler {
     public static void init() {
         CHANNEL.registerMessage(ID_COUNT.getAndIncrement(), ClientMessagePlayerShoot.class, ClientMessagePlayerShoot::encode, ClientMessagePlayerShoot::decode, ClientMessagePlayerShoot::handle,
                 Optional.of(NetworkDirection.PLAY_TO_SERVER));
+        CHANNEL.registerMessage(ID_COUNT.getAndIncrement(), ClientMessagePlayerShootBegin.class, ClientMessagePlayerShootBegin::encode, ClientMessagePlayerShootBegin::decode, ClientMessagePlayerShootBegin::handle,
+                Optional.of(NetworkDirection.PLAY_TO_SERVER));
+        CHANNEL.registerMessage(ID_COUNT.getAndIncrement(), ClientMessagePlayerShootEnd.class, ClientMessagePlayerShootEnd::encode, ClientMessagePlayerShootEnd::decode, ClientMessagePlayerShootEnd::handle,
+                Optional.of(NetworkDirection.PLAY_TO_SERVER));
         CHANNEL.registerMessage(ID_COUNT.getAndIncrement(), ClientMessagePlayerReloadGun.class, ClientMessagePlayerReloadGun::encode, ClientMessagePlayerReloadGun::decode, ClientMessagePlayerReloadGun::handle,
                 Optional.of(NetworkDirection.PLAY_TO_SERVER));
         CHANNEL.registerMessage(ID_COUNT.getAndIncrement(), ClientMessagePlayerCancelReload.class, ClientMessagePlayerCancelReload::encode, ClientMessagePlayerCancelReload::decode, ClientMessagePlayerCancelReload::handle,

--- a/src/main/java/com/tacz/guns/network/message/ClientMessagePlayerShootBegin.java
+++ b/src/main/java/com/tacz/guns/network/message/ClientMessagePlayerShootBegin.java
@@ -8,9 +8,7 @@ import net.minecraftforge.network.NetworkEvent;
 import java.util.function.Supplier;
 
 public class ClientMessagePlayerShootBegin {
-    /**
-     * 这里的 timestamp 应该是基于 base timestamp 的相对值
-     */
+
     private long timestamp;
 
     public ClientMessagePlayerShootBegin() {

--- a/src/main/java/com/tacz/guns/network/message/ClientMessagePlayerShootBegin.java
+++ b/src/main/java/com/tacz/guns/network/message/ClientMessagePlayerShootBegin.java
@@ -1,0 +1,44 @@
+package com.tacz.guns.network.message;
+
+import com.tacz.guns.api.entity.IGunOperator;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.function.Supplier;
+
+public class ClientMessagePlayerShootBegin {
+    /**
+     * 这里的 timestamp 应该是基于 base timestamp 的相对值
+     */
+    private long timestamp;
+
+    public ClientMessagePlayerShootBegin() {
+    }
+
+    public ClientMessagePlayerShootBegin(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public static void encode(ClientMessagePlayerShootBegin message, FriendlyByteBuf buf) {
+        buf.writeLong(message.timestamp);
+    }
+
+    public static ClientMessagePlayerShootBegin decode(FriendlyByteBuf buf) {
+        return new ClientMessagePlayerShootBegin(buf.readLong());
+    }
+
+    public static void handle(ClientMessagePlayerShootBegin message, Supplier<NetworkEvent.Context> contextSupplier) {
+        NetworkEvent.Context context = contextSupplier.get();
+        if (context.getDirection().getReceptionSide().isServer()) {
+            context.enqueueWork(() -> {
+                ServerPlayer entity = context.getSender();
+                if (entity == null) {
+                    return;
+                }
+                IGunOperator.fromLivingEntity(entity).startFullAuto(message.timestamp);
+            });
+        }
+        context.setPacketHandled(true);
+    }
+}

--- a/src/main/java/com/tacz/guns/network/message/ClientMessagePlayerShootEnd.java
+++ b/src/main/java/com/tacz/guns/network/message/ClientMessagePlayerShootEnd.java
@@ -1,0 +1,44 @@
+package com.tacz.guns.network.message;
+
+import com.tacz.guns.api.entity.IGunOperator;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.function.Supplier;
+
+public class ClientMessagePlayerShootEnd {
+    /**
+     * 这里的 timestamp 应该是基于 base timestamp 的相对值
+     */
+    private long timestamp;
+
+    public ClientMessagePlayerShootEnd() {
+    }
+
+    public ClientMessagePlayerShootEnd(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public static void encode(ClientMessagePlayerShootEnd message, FriendlyByteBuf buf) {
+        buf.writeLong(message.timestamp);
+    }
+
+    public static ClientMessagePlayerShootEnd decode(FriendlyByteBuf buf) {
+        return new ClientMessagePlayerShootEnd(buf.readLong());
+    }
+
+    public static void handle(ClientMessagePlayerShootEnd message, Supplier<NetworkEvent.Context> contextSupplier) {
+        NetworkEvent.Context context = contextSupplier.get();
+        if (context.getDirection().getReceptionSide().isServer()) {
+            context.enqueueWork(() -> {
+                ServerPlayer entity = context.getSender();
+                if (entity == null) {
+                    return;
+                }
+                IGunOperator.fromLivingEntity(entity).stopFullAuto(message.timestamp);
+            });
+        }
+        context.setPacketHandled(true);
+    }
+}

--- a/src/main/java/com/tacz/guns/network/message/ClientMessagePlayerShootEnd.java
+++ b/src/main/java/com/tacz/guns/network/message/ClientMessagePlayerShootEnd.java
@@ -8,9 +8,7 @@ import net.minecraftforge.network.NetworkEvent;
 import java.util.function.Supplier;
 
 public class ClientMessagePlayerShootEnd {
-    /**
-     * 这里的 timestamp 应该是基于 base timestamp 的相对值
-     */
+
     private long timestamp;
 
     public ClientMessagePlayerShootEnd() {
@@ -36,7 +34,7 @@ public class ClientMessagePlayerShootEnd {
                 if (entity == null) {
                     return;
                 }
-                IGunOperator.fromLivingEntity(entity).stopFullAuto(message.timestamp);
+                IGunOperator.fromLivingEntity(entity).stopFullAuto();
             });
         }
         context.setPacketHandled(true);

--- a/src/main/java/com/tacz/guns/network/message/ServerMessageGunStop.java
+++ b/src/main/java/com/tacz/guns/network/message/ServerMessageGunStop.java
@@ -1,0 +1,49 @@
+package com.tacz.guns.network.message;
+
+import com.tacz.guns.api.entity.IGunOperator;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.function.Supplier;
+
+public class ServerMessageGunStop {
+
+    private final int shooterId;
+
+    public ServerMessageGunStop(int shooterId) {
+        this.shooterId = shooterId;
+    }
+
+    public static void encode(ServerMessageGunStop message, FriendlyByteBuf buf) {
+        buf.writeVarInt(message.shooterId);
+    }
+
+    public static ServerMessageGunStop decode(FriendlyByteBuf buf) {
+        int shooterId = buf.readVarInt();
+        return new ServerMessageGunStop(shooterId);
+    }
+
+    public static void handle(ServerMessageGunStop message, Supplier<NetworkEvent.Context> contextSupplier) {
+        NetworkEvent.Context context = contextSupplier.get();
+        if (context.getDirection().getReceptionSide().isClient()) {
+            context.enqueueWork(() -> doClientEvent(message, context));
+        }
+        context.setPacketHandled(true);
+    }
+
+    @OnlyIn(Dist.CLIENT)
+    private static void doClientEvent(ServerMessageGunStop message, NetworkEvent.Context context) {
+        ClientLevel level = Minecraft.getInstance().level;
+        if (level == null) {
+            return;
+        }
+        if (level.getEntity(message.shooterId) instanceof LivingEntity shooter) {
+            IGunOperator.fromLivingEntity(shooter).stopFullAuto();
+        }
+    }
+}

--- a/src/main/java/com/tacz/guns/util/ShootBus.java
+++ b/src/main/java/com/tacz/guns/util/ShootBus.java
@@ -1,0 +1,63 @@
+package com.tacz.guns.util;
+
+import com.tacz.guns.GunMod;
+import com.tacz.guns.api.entity.IGunOperator;
+import com.tacz.guns.client.gameplay.LocalPlayerDataHolder;
+import com.tacz.guns.entity.shooter.ShooterDataHolder;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import net.minecraft.client.Minecraft;
+import net.minecraft.server.level.ServerEntity;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+import java.util.Iterator;
+import java.util.UUID;
+
+import static com.tacz.guns.util.InputExtraCheck.isInGame;
+@Mod.EventBusSubscriber(modid = GunMod.MOD_ID)
+public class ShootBus {
+    private static ShootBus instance;
+    private final Object2IntOpenHashMap<UUID> counter = new Object2IntOpenHashMap<>();
+
+    public ShootBus() {
+        if (instance == null) {
+            instance = this;
+        }
+        counter.defaultReturnValue(0); // 未找到时返回 0，而非 null
+    }
+    public static ShootBus getInstance() {
+        return instance;
+    }
+    // 射出一发子弹 → 原子化 +1
+    public static void addShot(UUID playerUUID) {
+        ShootBus.getInstance().counter.addTo(playerUUID, 1);
+    }
+    @SubscribeEvent
+    // 每刻调用：处理所有累积子弹，然后清空
+    public static void processAndClear(TickEvent.ServerTickEvent event) {
+        if (event.phase != TickEvent.Phase.END && !isInGame()) {
+            return;
+        }
+        Iterator<Object2IntMap.Entry<UUID>> it = ShootBus.getInstance().counter.object2IntEntrySet().iterator();
+        while (it.hasNext()) {
+            Object2IntMap.Entry<UUID> entry = it.next();
+            UUID playerUUID = entry.getKey();
+            int bulletCount = entry.getIntValue();
+            ServerPlayer player = event.getServer().getPlayerList().getPlayer(playerUUID);
+            if (player == null) continue;
+            IGunOperator shooter = IGunOperator.fromLivingEntity(player);
+            GunMod.LOGGER.info("ShootBus:56 {} {}", playerUUID.toString(), bulletCount);
+            ShooterDataHolder data = shooter.getDataHolder();
+            // 射击
+            shooter.shoot(player::getXRot, player::getYRot, System.currentTimeMillis() - data.baseTimestamp, bulletCount, true);
+            // 立即从映射中删除，保证下一轮遍历只有真正开火的枪
+            it.remove();
+        }
+    }
+
+}

--- a/src/main/java/com/tacz/guns/util/ShootBus.java
+++ b/src/main/java/com/tacz/guns/util/ShootBus.java
@@ -2,15 +2,10 @@ package com.tacz.guns.util;
 
 import com.tacz.guns.GunMod;
 import com.tacz.guns.api.entity.IGunOperator;
-import com.tacz.guns.client.gameplay.LocalPlayerDataHolder;
 import com.tacz.guns.entity.shooter.ShooterDataHolder;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
-import net.minecraft.client.Minecraft;
-import net.minecraft.server.level.ServerEntity;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.entity.LivingEntity;
-import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -19,6 +14,10 @@ import java.util.Iterator;
 import java.util.UUID;
 
 import static com.tacz.guns.util.InputExtraCheck.isInGame;
+
+/**
+ * 增加了一条专门用于处理高频射击的线
+ */
 @Mod.EventBusSubscriber(modid = GunMod.MOD_ID)
 public class ShootBus {
     private static ShootBus instance;
@@ -33,12 +32,18 @@ public class ShootBus {
     public static ShootBus getInstance() {
         return instance;
     }
-    // 射出一发子弹 → 原子化 +1
+
+    /**
+     * 射击一发子弹（只记录）
+     * @param playerUUID 设计者的UUID
+     */
     public static void addShot(UUID playerUUID) {
         ShootBus.getInstance().counter.addTo(playerUUID, 1);
     }
     @SubscribeEvent
-    // 每刻调用：处理所有累积子弹，然后清空
+    /**
+     * 每刻统一处理一次，把积攒的所有子弹作为一个弹射物发射出去
+     */
     public static void processAndClear(TickEvent.ServerTickEvent event) {
         if (event.phase != TickEvent.Phase.END && !isInGame()) {
             return;
@@ -51,11 +56,10 @@ public class ShootBus {
             ServerPlayer player = event.getServer().getPlayerList().getPlayer(playerUUID);
             if (player == null) continue;
             IGunOperator shooter = IGunOperator.fromLivingEntity(player);
-            GunMod.LOGGER.info("ShootBus:56 {} {}", playerUUID.toString(), bulletCount);
             ShooterDataHolder data = shooter.getDataHolder();
             // 射击
             shooter.shoot(player::getXRot, player::getYRot, System.currentTimeMillis() - data.baseTimestamp, bulletCount, true);
-            // 立即从映射中删除，保证下一轮遍历只有真正开火的枪
+            //从中清除
             it.remove();
         }
     }

--- a/src/main/java/com/tacz/guns/util/ShootBus.java
+++ b/src/main/java/com/tacz/guns/util/ShootBus.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 import static com.tacz.guns.util.InputExtraCheck.isInGame;
 
 /**
- * 增加了一条专门用于处理高频射击的线
+ * 增加了一条专门用于处理全自动射击的线
  */
 @Mod.EventBusSubscriber(modid = GunMod.MOD_ID)
 public class ShootBus {
@@ -35,7 +35,7 @@ public class ShootBus {
 
     /**
      * 射击一发子弹（只记录）
-     * @param playerUUID 设计者的UUID
+     * @param playerUUID 射击者的UUID
      */
     public static void addShot(UUID playerUUID) {
         ShootBus.getInstance().counter.addTo(playerUUID, 1);

--- a/src/main/java/com/tacz/guns/util/ShootBus.java
+++ b/src/main/java/com/tacz/guns/util/ShootBus.java
@@ -7,6 +7,7 @@ import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
@@ -16,29 +17,22 @@ import java.util.UUID;
 import static com.tacz.guns.util.InputExtraCheck.isInGame;
 
 /**
- * 增加了一条专门用于处理全自动射击的线
+ * 增加了一个专门用于处理全自动射击的类
  */
 @Mod.EventBusSubscriber(modid = GunMod.MOD_ID)
 public class ShootBus {
-    private static ShootBus instance;
-    private final Object2IntOpenHashMap<UUID> counter = new Object2IntOpenHashMap<>();
-
-    public ShootBus() {
-        if (instance == null) {
-            instance = this;
-        }
-        counter.defaultReturnValue(0); // 未找到时返回 0，而非 null
+    private static final Object2IntOpenHashMap<UUID> SHOT_COUNTER = new Object2IntOpenHashMap<>();
+    static {
+        SHOT_COUNTER.defaultReturnValue(0);
     }
-    public static ShootBus getInstance() {
-        return instance;
-    }
+    private ShootBus() {}
 
     /**
      * 射击一发子弹（只记录）
      * @param playerUUID 射击者的UUID
      */
     public static void addShot(UUID playerUUID) {
-        ShootBus.getInstance().counter.addTo(playerUUID, 1);
+        ShootBus.SHOT_COUNTER.addTo(playerUUID, 1);
     }
     @SubscribeEvent
     /**
@@ -48,13 +42,16 @@ public class ShootBus {
         if (event.phase != TickEvent.Phase.END && !isInGame()) {
             return;
         }
-        Iterator<Object2IntMap.Entry<UUID>> it = ShootBus.getInstance().counter.object2IntEntrySet().iterator();
+        Iterator<Object2IntMap.Entry<UUID>> it = ShootBus.SHOT_COUNTER.object2IntEntrySet().iterator();
         while (it.hasNext()) {
             Object2IntMap.Entry<UUID> entry = it.next();
             UUID playerUUID = entry.getKey();
             int bulletCount = entry.getIntValue();
             ServerPlayer player = event.getServer().getPlayerList().getPlayer(playerUUID);
-            if (player == null) continue;
+            if (player == null) {
+                it.remove();
+                continue;
+            }
             IGunOperator shooter = IGunOperator.fromLivingEntity(player);
             ShooterDataHolder data = shooter.getDataHolder();
             // 射击
@@ -63,5 +60,10 @@ public class ShootBus {
             it.remove();
         }
     }
-
+    @SubscribeEvent
+    public static void onPlayerLogout(PlayerEvent.PlayerLoggedOutEvent event) {
+        if (event.getEntity() instanceof ServerPlayer serverPlayer) {
+            SHOT_COUNTER.removeInt(serverPlayer.getUUID());
+        }
+    }
 }

--- a/src/main/java/com/tacz/guns/util/ShootBus.java
+++ b/src/main/java/com/tacz/guns/util/ShootBus.java
@@ -12,7 +12,10 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
 import java.util.Iterator;
+import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.tacz.guns.util.InputExtraCheck.isInGame;
 
@@ -21,18 +24,28 @@ import static com.tacz.guns.util.InputExtraCheck.isInGame;
  */
 @Mod.EventBusSubscriber(modid = GunMod.MOD_ID)
 public class ShootBus {
-    private static final Object2IntOpenHashMap<UUID> SHOT_COUNTER = new Object2IntOpenHashMap<>();
+    private static class ShootingSession {
+        final long startNano;          // 开始射击时的 System.nanoTime()
+        final double bulletsPerNano;   // 每秒射速转换为每纳秒子弹数 (RPM / 60 / 1e9)
+        int lastTotalBullets;         // 上一次发射时计算的总子弹数（整数部分）
+
+        ShootingSession(int rpm) {
+            this.startNano = System.nanoTime();
+            this.bulletsPerNano = rpm / 60.0 / 1_000_000_000.0;
+            this.lastTotalBullets = 0;
+        }
+    }
+    private static final ConcurrentHashMap<UUID, ShootingSession> ACTIVE_SESSIONS = new ConcurrentHashMap<>();
     static {
-        SHOT_COUNTER.defaultReturnValue(0);
     }
     private ShootBus() {}
 
-    /**
-     * 射击一发子弹（只记录）
-     * @param playerUUID 射击者的UUID
-     */
-    public static void addShot(UUID playerUUID) {
-        ShootBus.SHOT_COUNTER.addTo(playerUUID, 1);
+    public static void beginShot(UUID playerUUID, int rpm) {
+        ACTIVE_SESSIONS.put(playerUUID, new ShootingSession(rpm));
+    }
+
+    public static void endShot(UUID playerUUID) {
+        ACTIVE_SESSIONS.remove(playerUUID);
     }
     @SubscribeEvent
     /**
@@ -42,28 +55,34 @@ public class ShootBus {
         if (event.phase != TickEvent.Phase.END && !isInGame()) {
             return;
         }
-        Iterator<Object2IntMap.Entry<UUID>> it = ShootBus.SHOT_COUNTER.object2IntEntrySet().iterator();
+        long nowNano = System.nanoTime();
+        Iterator<Map.Entry<UUID, ShootingSession>> it = ShootBus.ACTIVE_SESSIONS.entrySet().iterator();
         while (it.hasNext()) {
-            Object2IntMap.Entry<UUID> entry = it.next();
+            Map.Entry<UUID, ShootingSession> entry = it.next();
             UUID playerUUID = entry.getKey();
-            int bulletCount = entry.getIntValue();
+            ShootingSession session= entry.getValue();
             ServerPlayer player = event.getServer().getPlayerList().getPlayer(playerUUID);
             if (player == null) {
                 it.remove();
                 continue;
             }
+            //计算射出多少发和最后一次射击的精确时间戳
+
+            int bulletCount = (int) ((nowNano - session.startNano) * session.bulletsPerNano + 1) - session.lastTotalBullets; //向下取整
+            session.lastTotalBullets += bulletCount;
+            //GunMod.LOGGER.info("{} {} {} {}", System.nanoTime(), bulletCount, session.startNano, session.lastTotalBullets);
+            if(bulletCount == 0)
+                return;
+            // 射击
             IGunOperator shooter = IGunOperator.fromLivingEntity(player);
             ShooterDataHolder data = shooter.getDataHolder();
-            // 射击
             shooter.shoot(player::getXRot, player::getYRot, System.currentTimeMillis() - data.baseTimestamp, bulletCount, true);
-            //从中清除
-            it.remove();
         }
     }
     @SubscribeEvent
     public static void onPlayerLogout(PlayerEvent.PlayerLoggedOutEvent event) {
         if (event.getEntity() instanceof ServerPlayer serverPlayer) {
-            SHOT_COUNTER.removeInt(serverPlayer.getUUID());
+            ACTIVE_SESSIONS.remove(serverPlayer.getUUID());
         }
     }
 }


### PR DESCRIPTION
# 我尝试适配了超过1200射速的武器

我注意到有部分枪包中射速超过1200，在原版TACZ中这些武器的射速会被强行降低至1200每分钟

我通过将全自动的发射逻辑从Minecraft中独立出来的方式一定程度上解决的DPS低于理想值和弹药消耗低于理想值的问题。

## 改动与说明

### 网络部分

增加了三个数据包，分别为`ClientMessagePlayerShootBegin`、`ClientMessagePlayerShootEnd`和`ServerMessageGunStop`，用途分别为客户端通知服务器开始全自动射击，客户端通知服务端停止全自动射击，服务端强行停止客户端继续射击（由于缺少弹药）。

### 射击逻辑部分

我先简要说明一下修改后的全自动射击流程：摁下射击键后客户端想服务器发送`ClientMessagePlayerShootBegin`同时自己启动一个子线程用于播放音效和提供后坐力，服务器收到后在`LivingEntityShoot.startFullAuto`方法中启动一个子线程用于向`ShootBus`类声明自己射出去的子弹数量，`ShootBus.processAndClear`方法注册了一个监听器，用于每刻将每个玩家打出去的子弹分别进行一次射击，避免了大量子弹实体造成的卡顿。当客户端松开射击键时，会发送`ClientMessagePlayerShootEnd`包并杀死自身创建的`Gun-AutoShoot-Scheduler`线程，服务器收到包后也会杀死自身创建的与该玩家绑定的`Gun-AutoShoot-Scheduler`线程。当服务器判定弹药打空之后会发送`ServerMessageGunStop`包直接调用客户端由Mixin注入的`LivingEntity.stopFullAuto`方法停止全自动射击。

### 伤害计算部分

往`EntityKineticBullet.onBulletTick`方法中加入了一个for循环用于多次计算一个子弹实体中包含的多个子弹造成的伤害。

### 几乎没有对已有的半自动射击和爆发射击做出改变

### 杂项

新引入了`it.unimi.dsi:fastutil`库用于`ShootBus`类中