### PR TITLE
[Security] 配件改装包类型混淆导致配件复制 + 配件锁服务端未校验

### DIFF
--- a/src/main/java/com/tacz/guns/network/message/ClientMessageRefitGun.java
+++ b/src/main/java/com/tacz/guns/network/message/ClientMessageRefitGun.java
@@ -1,5 +1,6 @@
 package com.tacz.guns.network.message;
 
+import com.tacz.guns.api.item.IAttachment;
 import com.tacz.guns.api.item.IGun;
 import com.tacz.guns.api.item.attachment.AttachmentType;
 import com.tacz.guns.network.NetworkHandler;
@@ -46,14 +47,24 @@ public class ClientMessageRefitGun {
                 ItemStack gunItem = inventory.getItem(message.gunSlotIndex);
                 IGun iGun = IGun.getIGunOrNull(gunItem);
                 if (iGun != null) {
+                    // 服务端校验配件锁
+                    if (iGun.hasAttachmentLock(gunItem)) {
+                        return;
+                    }
                     if (iGun.allowAttachment(gunItem, attachmentItem)) {
-                        ItemStack oldAttachmentItem = iGun.getAttachment(gunItem, message.attachmentType);
+                        // 使用配件物品自身的真实类型，而非客户端传入的 attachmentType
+                        IAttachment iAttachment = IAttachment.getIAttachmentOrNull(attachmentItem);
+                        if (iAttachment == null) {
+                            return;
+                        }
+                        AttachmentType realType = iAttachment.getType(attachmentItem);
+                        ItemStack oldAttachmentItem = iGun.getAttachment(gunItem, realType);
                         iGun.installAttachment(gunItem, attachmentItem);
                         // 刷新配件数据
                         AttachmentPropertyManager.postChangeEvent(player, gunItem);
                         inventory.setItem(message.attachmentSlotIndex, oldAttachmentItem);
                         // 如果卸载的是扩容弹匣，吐出所有子弹
-                        if (message.attachmentType == AttachmentType.EXTENDED_MAG) {
+                        if (realType == AttachmentType.EXTENDED_MAG) {
                             iGun.dropAllAmmo(player, gunItem);
                         }
                         player.inventoryMenu.broadcastChanges();

--- a/src/main/java/com/tacz/guns/network/message/ClientMessageUnloadAttachment.java
+++ b/src/main/java/com/tacz/guns/network/message/ClientMessageUnloadAttachment.java
@@ -42,6 +42,10 @@ public class ClientMessageUnloadAttachment {
                 ItemStack gunItem = inventory.getItem(message.gunSlotIndex);
                 IGun iGun = IGun.getIGunOrNull(gunItem);
                 if (iGun != null) {
+                    // 服务端校验配件锁
+                    if (iGun.hasAttachmentLock(gunItem)) {
+                        return;
+                    }
                     ItemStack attachmentItem = iGun.getAttachment(gunItem, message.attachmentType);
                     if (!attachmentItem.isEmpty() && inventory.add(attachmentItem)) {
                         iGun.unloadAttachment(gunItem, message.attachmentType);


### PR DESCRIPTION
## 漏洞概述

配件改装系统存在**类型混淆 + 服务端不校验锁**两个安全问题，可被外挂利用实现配件无限复制并绕过配件锁定。

## 严重程度：P0（Critical）

## 漏洞详情

### 1. 类型混淆导致配件复制

**文件**: `ClientMessageRefitGun.java`

服务端信任客户端传来的 `attachmentType`，但 `installAttachment` 实际按配件物品自身类型写入：

```java
// 旧代码 — getAttachment 用客户端传入的 type，installAttachment 用配件自身 type
ItemStack oldAttachmentItem = iGun.getAttachment(gunItem, message.attachmentType); // ← 客户端控制
iGun.installAttachment(gunItem, attachmentItem); // ← 按 iAttachment.getType() 写入
inventory.setItem(message.attachmentSlotIndex, oldAttachmentItem);
```

**利用方式**：伪造包让 `attachmentType=SCOPE`，但实际配件是 MUZZLE。服务器从 SCOPE 槽取出旧配件放入背包，但 SCOPE 槽本身不被清空，形成复制。

### 2. 配件锁服务端未校验

**文件**: `ClientMessageRefitGun.java`, `ClientMessageUnloadAttachment.java`

`AttachmentLock` 仅在客户端按键层阻止（`RefitKey`），服务端 handle 方法无任何锁校验，外挂可直接绕过。

## 影响

- 可批量复制高价值配件（瞄具、消音器等）
- 快速堆出异常伤害/射速/后坐力收益
- 经济和战斗双重破坏

## 修复内容

1. `ClientMessageRefitGun`: 使用 `iAttachment.getType(attachmentItem)` 替代 `message.attachmentType` 获取旧配件
2. `ClientMessageRefitGun` + `ClientMessageUnloadAttachment`: 添加 `iGun.hasAttachmentLock()` 服务端校验