### PR TITLE
[Security] 射击冷却基于客户端时间戳，可伪造实现瞬时超额射速

### DIFF
--- a/src/main/java/com/tacz/guns/entity/shooter/LivingEntityShoot.java
+++ b/src/main/java/com/tacz/guns/entity/shooter/LivingEntityShoot.java
@@ -52,9 +52,11 @@ public class LivingEntityShoot {
             return ShootResult.ID_NOT_EXIST;
         }
         CommonGunIndex gunIndex = gunIndexOptional.get();
+        // 使用服务端时间戳计算冷却，防止客户端伪造时间戳绕过射速限制
+        long serverTimestamp = System.currentTimeMillis() - data.baseTimestamp;
         if (SyncConfig.SERVER_SHOOT_COOLDOWN_V.get()) {
             // 判断射击是否正在冷却
-            long coolDown = getShootCoolDown(timestamp);
+            long coolDown = getShootCoolDown(serverTimestamp);
             if (coolDown == -1) {
                 // 一般来说不太可能为 -1，原因未知
                 return ShootResult.UNKNOWN_FAIL;
@@ -135,7 +137,7 @@ public class LivingEntityShoot {
         NetworkHandler.sendToTrackingEntity(new ServerMessageGunShoot(shooter.getId(), currentGunItem), shooter);
         data.lastShootTimestamp = data.shootTimestamp;
         data.heatTimestamp = System.currentTimeMillis();
-        data.shootTimestamp = timestamp;
+        data.shootTimestamp = serverTimestamp;
         // 执行枪械射击逻辑
         if (iGun instanceof AbstractGunItem logicGun) {
             logicGun.shoot(data, currentGunItem, pitch, yaw, shooter);


### PR DESCRIPTION
## 漏洞概述

射击冷却判定完全基于客户端上传的 timestamp，外挂可在同一 tick 内连发多包突破射速限制。

## 严重程度：P1（High）

## 漏洞详情

**文件**: `LivingEntityShoot.java`

冷却计算和记录都使用客户端时间戳：

```java
// 冷却判定 — timestamp 来自客户端
long coolDown = getShootCoolDown(timestamp);

// getShootCoolDown 内部：
long interval = timestamp - data.shootTimestamp; // 两个值都是客户端控制的

// 射击成功后记录：
data.shootTimestamp = timestamp; // 存的也是客户端值
```

网络窗口校验允许 timestamp 比服务端当前时间最多快 300ms。

**利用方式**：外挂在同一 tick 连发多个 `ClientMessagePlayerShoot` 包，时间戳递增但都落在 +300ms 窗口内。

示例：射击间隔 100ms 的枪，单 tick 内发送 ts=0/100/200/300 四个包，服务端每次都认为冷却已过，形成瞬时 4 倍爆发。

## 影响

- PVP 中可显著突破预期 TTK
- 战斗平衡破坏

## 修复内容

冷却判定和 `shootTimestamp` 记录改用服务端时间戳 `System.currentTimeMillis() - baseTimestamp`，客户端 timestamp 仅保留用于网络延迟窗口校验。