### PR TITLE
Fix guns unable to fire after client-only player respawn

### DIFF
--- a/src/main/java/com/tacz/guns/client/event/RefreshClonePlayerDataEvent.java
+++ b/src/main/java/com/tacz/guns/client/event/RefreshClonePlayerDataEvent.java
@@ -1,7 +1,10 @@
 package com.tacz.guns.client.event;
 
 import com.tacz.guns.GunMod;
+import com.tacz.guns.api.client.gameplay.IClientPlayerGunOperator;
 import com.tacz.guns.api.entity.IGunOperator;
+import com.tacz.guns.entity.sync.core.DataHolder;
+import com.tacz.guns.entity.sync.core.SyncedEntityData;
 import com.tacz.guns.util.DelayedTask;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraftforge.api.distmarker.Dist;
@@ -10,6 +13,7 @@ import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
+import java.util.HashMap;
 import java.util.function.BooleanSupplier;
 
 /**
@@ -19,7 +23,21 @@ import java.util.function.BooleanSupplier;
 public class RefreshClonePlayerDataEvent {
     @SubscribeEvent
     public static void onClientPlayerClone(ClientPlayerNetworkEvent.Clone event) {
+        LocalPlayer oldPlayer = event.getOldPlayer();
         LocalPlayer newPlayer = event.getNewPlayer();
+        // 服务端只在实体重新加入世界时全量同步 SyncedEntityData。如果只有客户端重建了玩家实体（例如换皮肤模组/插件
+        // 发送的 respawn 包），服务端不会重新同步，新实体会退回默认值（-1 的切枪/近战冷却），导致无法开火。
+        // 因此把旧实体的数据复制过来；死亡重生、跨维度时服务端随后仍会全量同步覆盖。
+        oldPlayer.reviveCaps();
+        DataHolder oldHolder = SyncedEntityData.instance().getDataHolder(oldPlayer);
+        DataHolder newHolder = SyncedEntityData.instance().getDataHolder(newPlayer);
+        if (oldHolder != null && newHolder != null) {
+            newHolder.dataMap = new HashMap<>(oldHolder.dataMap);
+        }
+        oldPlayer.invalidateCaps();
+        // 基时间戳同理，只在服务端下发同步消息时更新，丢失会导致开火包的时间戳校验失败
+        IClientPlayerGunOperator.fromLocalPlayer(newPlayer).getDataHolder().clientBaseTimestamp =
+                IClientPlayerGunOperator.fromLocalPlayer(oldPlayer).getDataHolder().clientBaseTimestamp;
         // 但是这个事件触发时，玩家的背包并未同步，导致无法读取枪械数据进行配件属性缓存的刷新
         // 延迟 10 tick 执行缓存刷新就好了
         DelayedTask.add(() -> IGunOperator.fromLivingEntity(newPlayer).initialData(), 10);


### PR DESCRIPTION
Fixes #610.

## Root cause

The SkinRestorer mod refreshes a player's skin by sending `ClientboundRespawnPacket` to that player (server plugins like the one in #610 use similar logic). The client discards its `LocalPlayer` and creates a new one, but the server-side entity is untouched.

TACZ keeps per-entity state in two places that don't survive this:

1. **`SyncedEntityData` capability** - the new client entity falls back to defaults (`DRAW_COOL_DOWN = -1`, `MELEE_COOL_DOWN = -1`). The server only re-sends these values on `EntityJoinLevelEvent` / `StartTracking`, which never fire here, and dirty-tracking never triggers because the server-side values didn't change. `LocalPlayerShoot.preCheck` then returns `IS_DRAWING` forever (`getSynDrawCoolDown() != 0`), so the fire packet is never sent. This is why disabling the server shoot checks doesn't help, and why death or dimension change (a real server-side rejoin) fixes it.
2. **`LocalPlayerDataHolder.clientBaseTimestamp`** - reset to -1 on the new player, so even after the synced data recovers, the first fire packet fails timestamp validation (`NETWORK_FAIL`) until the server re-syncs.

## Fix

In the existing `ClientPlayerNetworkEvent.Clone` handler (`RefreshClonePlayerDataEvent`), copy the `SyncedEntityData` holder contents and `clientBaseTimestamp` from the old player to the new one — the same thing vanilla does with entity data on `KEEP_ALL_DATA`, and the client-side mirror of the copy `SyncedEntityDataEvent.onPlayerClone` already does on the server. On death respawn or dimension change the server still performs its full sync afterwards and overwrites the copied values, so those paths are unaffected.

## Testing

1.20.1 server with SkinRestorer + TACZ, client with TACZ: join, confirm firing works, change skin via `/skin set`, and firing keeps working. Without this patch the gun goes permanently silent after the skin change.