### PR TITLE
Fix Oculus stencil and first-person depth ordering

### DIFF
--- a/src/main/java/com/tacz/guns/compat/oculus/OculusCompat.java
+++ b/src/main/java/com/tacz/guns/compat/oculus/OculusCompat.java
@@ -4,6 +4,7 @@ import com.tacz.guns.compat.oculus.legacy.OculusCompatLegacy;
 import com.tacz.guns.compat.oculus.newly.OculusCompatNewly;
 import com.tacz.guns.init.CompatRegistry;
 import net.irisshaders.iris.api.v0.IrisApi;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraftforge.fml.ModList;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
@@ -17,6 +18,7 @@ public final class OculusCompat {
     private static Supplier<Boolean> IS_RENDER_SHADOW_SUPPER;
 
     public static void initCompat() {
+        Minecraft.getInstance().getMainRenderTarget().enableStencil();
         ModList.get().getModContainerById(CompatRegistry.OCULUS).ifPresent(mod -> {
             if (mod.getModInfo().getVersion().compareTo(VERSION) >= 0) {
                 END_BATCH_FUNCTION = OculusCompatNewly::endBatch;

--- a/src/main/java/com/tacz/guns/init/CompatRegistry.java
+++ b/src/main/java/com/tacz/guns/init/CompatRegistry.java
@@ -7,6 +7,7 @@ import com.tacz.guns.compat.oculus.OculusCompat;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.fml.InterModComms;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
@@ -20,6 +21,9 @@ public class CompatRegistry {
 
     @SubscribeEvent
     public static void onEnqueue(final InterModEnqueueEvent event) {
+        if (FMLEnvironment.dist == Dist.CLIENT) {
+            InterModComms.sendTo(OCULUS, "register_translucent_hand_item", ModItems.MODERN_KINETIC_GUN::getId);
+        }
         event.enqueueWork(() -> checkModLoad(CLOTH_CONFIG, () -> DistExecutor.safeRunWhenOn(Dist.CLIENT, () -> MenuIntegration::registerModsPage)));
         event.enqueueWork(() -> {
             if (FMLEnvironment.dist == Dist.CLIENT) {


### PR DESCRIPTION
## What changed

- Provision the main render target's stencil attachment during TACZ's existing Oculus compatibility initialization.
- Register TACZ's shared gun item ID with Oculus through Forge IMC so it uses the late first-person hand pass.

## Why

The first scoped-weapon draw previously called RenderTarget.enableStencil() in the middle of hand rendering. Forge can recreate the main color and depth attachments at that point, after Oculus and Distant Horizons have cached the old depth texture. Provisioning stencil before Oculus constructs its pipeline makes later render-time calls no-ops.

With Separate Entity Draws enabled, translucent player models are intentionally drawn after the solid hand pass. Registering the gun for Oculus's existing late hand pass prevents nearby players from compositing over the weapon and scope.

## Standalone compatibility

The IMC message contains only the existing gun ResourceLocation and is sent only on the physical client. TACZ has no compile-time Oculus dependency; absent or older Oculus builds ignore it, dedicated servers are unchanged, and shaders-disabled rendering keeps the vanilla path.

## Validation

- Full packaged build passed on Java 17 against Forge 1.20.1-47.4.22
- PR source compile passed with no custom version change
- Stencil/depth correction runtime-tested by the reporter
- Paired Oculus late-hand scope/stencil smoke test still requested

Refs #519
Refs Asek3/Oculus#797